### PR TITLE
Revised the class MondoCommand to reflect the changes from phenol

### DIFF
--- a/hpowbcli/src/main/java/org/monarchinitiative/hpoworkbench/cmd/MondoCommand.java
+++ b/hpowbcli/src/main/java/org/monarchinitiative/hpoworkbench/cmd/MondoCommand.java
@@ -7,7 +7,6 @@ import org.monarchinitiative.hpoworkbench.word.Hpo2Word;
 import org.monarchinitiative.phenol.base.PhenolException;
 import org.monarchinitiative.phenol.formats.generic.GenericRelationship;
 import org.monarchinitiative.phenol.formats.generic.GenericTerm;
-import org.monarchinitiative.phenol.io.obo.DbXref;
 import org.monarchinitiative.phenol.ontology.data.Dbxref;
 import org.monarchinitiative.phenol.ontology.data.ImmutableOntology;
 import org.monarchinitiative.phenol.ontology.data.TermId;
@@ -22,14 +21,11 @@ import java.util.Map;
  */
 public class MondoCommand extends HPOCommand {
     private static final Logger logger = LogManager.getLogger();
-
     private final String pathToMondoFile;
-
 
     public MondoCommand(String path) {
         pathToMondoFile=path;
     }
-
 
     @Override
     public void run() {
@@ -46,13 +42,11 @@ public class MondoCommand extends HPOCommand {
                 if (c++>5) break;
                 GenericTerm gt = termmap.get(tid);
                 logger.trace(String.format("%s [%s; %s] xrefs are ",gt.getName(),gt.getId(),gt.getDefinition() ));
-                List<org.monarchinitiative.phenol.ontology.data.Dbxref> xrefs = gt.getXrefs();
+                List<Dbxref> xrefs = gt.getXrefs();
                 for (Dbxref x : xrefs) {
                     logger.trace("\t%s",x.getName());
                 }
             }
-
-
         } catch (PhenolException e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
* I made a small change in the class MondoCommand to reflex the change in phenol, i.e. the removal of duplicated DbXref class. 
* I also confirmed that errors from missing curie_map.yaml were resolved when I ran HPOworkbench with the refactored phenol. However, I saw the error that mondo.obo is missing - I guess this happened because I didn't feed that file as input, but please let me know if you found any other errors. Thank you.