### PR TITLE
Move HPO tab code into separate controller, fix bug with property value removal. Add optional resources for Mondo support

### DIFF
--- a/hpowbcli/src/main/java/org/monarchinitiative/hpoworkbench/cmd/CountFrequencyCommand.java
+++ b/hpowbcli/src/main/java/org/monarchinitiative/hpoworkbench/cmd/CountFrequencyCommand.java
@@ -59,7 +59,7 @@ public class CountFrequencyCommand extends HPOCommand {
             } catch (PhenolException pe ) {
                 pe.printStackTrace(); //todo refacgtor
             }
-            Map<String,HpoDisease> annotationMap = aparser.getDisdeaseMap();
+            Map<String,HpoDisease> annotationMap = aparser.getDiseaseMap();
             LOGGER.error("Annotation count total " + annotationMap.size());
             Set<TermId> descendents = getDescendents(ontology, termId);
             descendentTermCount = descendents.size();

--- a/hpowbcli/src/main/java/org/monarchinitiative/hpoworkbench/cmd/DownloadCommand.java
+++ b/hpowbcli/src/main/java/org/monarchinitiative/hpoworkbench/cmd/DownloadCommand.java
@@ -42,11 +42,11 @@ public final class DownloadCommand extends HPOCommand {
 
 
     private void downloadPhenotypeAnnotationDotTab() {
-        // Now the same for the phenotype_annotation.tab file
-        String downloadLocation=String.format("%s%sphenotype_annotation.tab",downloadDirectory, File.separator);
+        // Now the same for the phenotype.hpoa file
+        String downloadLocation=String.format("%s%sphenotype.hpoa",downloadDirectory, File.separator);
         File f = new File(downloadLocation);
         if (f.exists()) {
-            LOGGER.trace("cowardly refusing to download phenoptype_annotation.tab, since it is already there");
+            LOGGER.trace("cowardly refusing to download phenotype.hpoa, since it is already there");
             return;
         }
         try {

--- a/hpowbcli/src/main/java/org/monarchinitiative/hpoworkbench/cmd/HpoStatsCommand.java
+++ b/hpowbcli/src/main/java/org/monarchinitiative/hpoworkbench/cmd/HpoStatsCommand.java
@@ -87,7 +87,7 @@ public class HpoStatsCommand extends HPOCommand  {
         hpoOntology=parser.getHPO();
         try {
             HPOAnnotationParser annotparser = new HPOAnnotationParser(annotpath, hpoOntology);
-            diseaseMap = annotparser.getDisdeaseMap();
+            diseaseMap = annotparser.getDiseaseMap();
         } catch (PhenolException pe) {
             pe.printStackTrace();
         }
@@ -143,7 +143,7 @@ public class HpoStatsCommand extends HPOCommand  {
     }
 
 
-    boolean diseaseAnnotatedToTermOfInterest(HpoDisease d) {
+    private boolean diseaseAnnotatedToTermOfInterest(HpoDisease d) {
         List<HpoAnnotation> tiwmlist= d.getPhenotypicAbnormalities();
         for (HpoAnnotation id:tiwmlist) {
           if (this.descendentsOfTheTermOfInterest.contains(id.getTermId()))
@@ -167,7 +167,6 @@ public class HpoStatsCommand extends HPOCommand  {
                 decipher.add(d);
             } else {
                 LOGGER.error("Did not recognize data base"+ database);
-                continue;
             }
         }
         String termname=hpoOntology.getTermMap().get(termOfInterest).getName();

--- a/hpowbcore/src/main/java/org/monarchinitiative/hpoworkbench/annotation/AnnotationMerger.java
+++ b/hpowbcore/src/main/java/org/monarchinitiative/hpoworkbench/annotation/AnnotationMerger.java
@@ -104,8 +104,8 @@ public class AnnotationMerger {
                 String label = ontology.getTermMap().get(ctid).getName();
                 System.out.println("Both diseases: " + label + "[" + ctid.getIdWithPrefix() + "]");
             }
-            List<TermSubClassPair> sclasspairs = catmerge.getD1subclassOfd2();
-            for (TermSubClassPair tscp : sclasspairs) {
+            List<SubClassTermPair> sclasspairs = catmerge.getD1subclassOfd2();
+            for (SubClassTermPair tscp : sclasspairs) {
                 TermId t1=tscp.getSubTid();
                 TermId t2=tscp.getSuperTid();
                 String label1 = ontology.getTermMap().get(t1).getName();
@@ -115,7 +115,7 @@ public class AnnotationMerger {
                         label2, t2.getIdWithPrefix(), diseaseName2));
             }
             sclasspairs = catmerge.getD2subclassOfd1();
-            for (TermSubClassPair tscp : sclasspairs) {
+            for (SubClassTermPair tscp : sclasspairs) {
                 TermId t2=tscp.getSubTid();
                 TermId t1=tscp.getSuperTid();
                 String label1 = ontology.getTermMap().get(t1).getName();

--- a/hpowbcore/src/main/java/org/monarchinitiative/hpoworkbench/annotation/AnnotationMerger.java
+++ b/hpowbcore/src/main/java/org/monarchinitiative/hpoworkbench/annotation/AnnotationMerger.java
@@ -23,6 +23,9 @@ public class AnnotationMerger {
     private final HpoDisease disease2;
     private final HpoOntology ontology;
 
+    private final String diseaseName1;
+    private final String diseaseName2;
+
 
     private List<TermId> sharedTerms;
 
@@ -38,6 +41,8 @@ public class AnnotationMerger {
     public AnnotationMerger(HpoDisease d1, HpoDisease d2, HpoOntology honto) {
         disease1=d1;
         disease2=d2;
+        diseaseName1=diseaseName(disease1);
+        diseaseName2=diseaseName(disease2);
         ontology=honto;
         categoryMap=new HpoCategoryMap();
         disease1ByCategory=new HashMap<>();
@@ -70,10 +75,10 @@ public class AnnotationMerger {
         System.out.println("############## " + hcat.getLabel() + " ##############");
         CategoryMerge catmerge = mergedCategoryMap.get(hcat);
         if (catmerge.onlyDisease1()) {
-            System.out.println(String.format("Only %s contains terms from category %s:",diseaseName(disease2),hcat.getLabel()));
+            System.out.println(String.format("Only %s contains terms from category %s:",diseaseName2,hcat.getLabel()));
             printTerms(catmerge.getDisease1onlyTerms());
         } else if (catmerge.onlyDisease2()) {
-            System.out.println(String.format("Only %s contains terms from category %s:",diseaseName(disease1),hcat.getLabel()));
+            System.out.println(String.format("Only %s contains terms from category %s:",diseaseName1,hcat.getLabel()));
             printTerms(catmerge.getDisease1onlyTerms());
         } else {
             List<TermId> commonterms = catmerge.getCommonTerms();
@@ -88,8 +93,8 @@ public class AnnotationMerger {
                 String label1 = ontology.getTermMap().get(t1).getName();
                 String label2 = ontology.getTermMap().get(t2).getName();
                 System.out.println(String.format("%s [%s] (%s)is subclass of %s [%s] (%s)",
-                        label1, t1.getIdWithPrefix(), diseaseName(disease1),
-                        label2, t2.getIdWithPrefix(),diseaseName(disease2)));
+                        label1, t1.getIdWithPrefix(), diseaseName1,
+                        label2, t2.getIdWithPrefix(), diseaseName2));
             }
             sclasspairs = catmerge.getD2subclassOfd1();
             for (TermSubClassPair tscp : sclasspairs) {
@@ -97,17 +102,17 @@ public class AnnotationMerger {
                 TermId t1=tscp.getSuperTid();
                 String label1 = ontology.getTermMap().get(t1).getName();
                 String label2 = ontology.getTermMap().get(t2).getName();
-                System.out.println(String.format("%s [%s] (%s)is subclass of %s [%s] (%s)",
-                        label2, t2.getIdWithPrefix(), diseaseName(disease2),
-                        label1, t1.getIdWithPrefix(),diseaseName(disease1)));
+                System.out.println(String.format("%s [%s] (%s) is subclass of %s [%s] (%s)",
+                        label2, t2.getIdWithPrefix(), diseaseName2,
+                        label1, t1.getIdWithPrefix(), diseaseName1));
             }
             for (TermId t1 : catmerge.getDisease1onlyTerms()) {
                 String label = ontology.getTermMap().get(t1).getName();
-                System.out.println(String.format("%s only: %s [%s]",diseaseName(disease1),label,t1.getIdWithPrefix()));
+                System.out.println(String.format("%s only: %s [%s]",diseaseName1,label,t1.getIdWithPrefix()));
             }
             for (TermId t2 : catmerge.getDisease2onlyTerms()) {
                 String label = ontology.getTermMap().get(t2).getName();
-                System.out.println(String.format("%s only: %s [%s]",diseaseName(disease2),label,t2.getIdWithPrefix()));
+                System.out.println(String.format("%s only: %s [%s]",diseaseName2,label,t2.getIdWithPrefix()));
             }
         }
     }
@@ -159,12 +164,12 @@ public class AnnotationMerger {
             Set<TermId> tidl2 = disease2ByCategory.get(hcat);
             Set<TermId> accountedFor = new HashSet<>();
             for (TermId t1 : tidl1) {
-                if (tidl2.contains(t1)) {
+                if (tidl2.contains(t1)) {  // Both disease have same annotation
                     accountedFor.add(t1);
                     catmerge.addCommonTerm(t1);
                 } else {
                     for (TermId t2 : tidl2) {
-                        if (existsPath(ontology, t1, t1)) {
+                        if (existsPath(ontology, t1, t2)) {
                             // t1 is a subclass of t2
                             accountedFor.add(t1);
                             accountedFor.add(t2);

--- a/hpowbcore/src/main/java/org/monarchinitiative/hpoworkbench/annotation/AnnotationMerger.java
+++ b/hpowbcore/src/main/java/org/monarchinitiative/hpoworkbench/annotation/AnnotationMerger.java
@@ -1,6 +1,9 @@
 package org.monarchinitiative.hpoworkbench.annotation;
 
 
+import com.google.common.collect.ImmutableList;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.monarchinitiative.phenol.formats.hpo.HpoAnnotation;
 import org.monarchinitiative.phenol.formats.hpo.HpoDisease;
 import org.monarchinitiative.phenol.formats.hpo.HpoOntology;
@@ -18,6 +21,7 @@ import java.util.stream.Collectors;
  */
 
 public class AnnotationMerger {
+    private static final Logger logger = LogManager.getLogger();
 
     private final HpoDisease disease1;
     private final HpoDisease disease2;
@@ -40,7 +44,18 @@ public class AnnotationMerger {
 
     public AnnotationMerger(HpoDisease d1, HpoDisease d2, HpoOntology honto) {
         disease1=d1;
+
         disease2=d2;
+        if (disease1==null) {
+            logger.trace("disease 1 == null");
+        } else {
+            logger.trace("disdase 1 ok, {}" , disease1.toString());
+        }
+        if (disease2==null) {
+            logger.trace("disease 2 == null");
+        } else {
+            logger.trace("disdase 2 ok, {}" , disease2.toString());
+        }
         diseaseName1=diseaseName(disease1);
         diseaseName2=diseaseName(disease2);
         ontology=honto;
@@ -53,11 +68,14 @@ public class AnnotationMerger {
 
 
     public void merge() {
+        mergeByCategory();
+    }
+
+    public void printToShell() {
         System.out.print("Disease 1: ");
         printDisease(disease1);
         System.out.print("Disease 2: ");
         printDisease(disease2);
-        mergeByCategory();
         outputByCategory();
         System.out.println();
         System.out.println();
@@ -128,8 +146,18 @@ public class AnnotationMerger {
 
 
     private void mergeByCategory() {
-        List<TermId> lst1 = disease1.getPhenotypicAbnormalities().stream().map(HpoAnnotation::getTermId).collect(Collectors.toList());
-        List<TermId> lst2 = disease2.getPhenotypicAbnormalities().stream().map(HpoAnnotation::getTermId).collect(Collectors.toList());
+        List<TermId> lst1;
+        if (disease1==null) {
+            lst1= ImmutableList.of();
+        } else {
+            lst1 = disease1.getPhenotypicAbnormalities().stream().map(HpoAnnotation::getTermId).collect(Collectors.toList());
+        }
+        List<TermId> lst2;
+        if (disease2==null) {
+            lst2=ImmutableList.of();
+        } else {
+            lst2 = disease2.getPhenotypicAbnormalities().stream().map(HpoAnnotation::getTermId).collect(Collectors.toList());
+        }
         HpoCategoryMap catmap1 =  new HpoCategoryMap();
         catmap1.addAnnotatedTerms(lst1,ontology);
         List<HpoCategory> catlist1=catmap1.getActiveCategoryList();
@@ -203,8 +231,13 @@ public class AnnotationMerger {
     }
 
 
+    public Map<HpoCategory,CategoryMerge> getMergedCategoryMap() {
+        return mergedCategoryMap;
+    }
 
     private String diseaseName(HpoDisease d) {
+        if (d==null) return "none";
+
         return d.getName() +"(" + d.getDatabase()+":"+ d.getDiseaseDatabaseId() +")";
     }
 

--- a/hpowbcore/src/main/java/org/monarchinitiative/hpoworkbench/annotation/CategoryMerge.java
+++ b/hpowbcore/src/main/java/org/monarchinitiative/hpoworkbench/annotation/CategoryMerge.java
@@ -24,8 +24,8 @@ public class CategoryMerge {
     private List<TermId> disease1onlyTerms;
     private List<TermId> disease2onlyTerms;
     private List<TermId> commonTerms;
-    private List<TermSubClassPair> d1subclassOfd2;
-    private List<TermSubClassPair> d2subclassOfd1;
+    private List<SubClassTermPair> d1subclassOfd2;
+    private List<SubClassTermPair> d2subclassOfd1;
 
     public CategoryMerge(String label,String d1name, String d2name){
         categoryLabel=label;
@@ -56,16 +56,16 @@ public class CategoryMerge {
     }
 
     public void addTermId1SubclassOfubOfTermId2(TermId t1,TermId t2) {
-        TermSubClassPair tscp = new TermSubClassPair(t1,t2);
+        SubClassTermPair tscp = new SubClassTermPair(t1,t2);
         d1subclassOfd2.add(tscp);
     }
 
-    public List<TermSubClassPair> getD2subclassOfd1() {
+    public List<SubClassTermPair> getD2subclassOfd1() {
         return d2subclassOfd1;
     }
 
     public void addTermId2SubclassOfubOfTermId1(TermId t2, TermId t1) {
-        TermSubClassPair tscp = new TermSubClassPair(t2,t1);
+        SubClassTermPair tscp = new SubClassTermPair(t2,t1);
         d2subclassOfd1.add(tscp);
     }
 
@@ -106,7 +106,7 @@ public class CategoryMerge {
         return commonTerms;
     }
 
-    public List<TermSubClassPair> getD1subclassOfd2() {
+    public List<SubClassTermPair> getD1subclassOfd2() {
         return d1subclassOfd2;
     }
 

--- a/hpowbcore/src/main/java/org/monarchinitiative/hpoworkbench/annotation/SubClassTermPair.java
+++ b/hpowbcore/src/main/java/org/monarchinitiative/hpoworkbench/annotation/SubClassTermPair.java
@@ -2,7 +2,11 @@ package org.monarchinitiative.hpoworkbench.annotation;
 
 import org.monarchinitiative.phenol.ontology.data.TermId;
 
-public class TermSubClassPair {
+/**
+ * This class models of pair of terms from two different diseases where one term is a strict subterm of the other one.
+ * @author <a href="mailto:peter.robinson@jax.org">Peter Robinson</a>
+ */
+public class SubClassTermPair {
 
     private final TermId subTid;
     private final TermId superTid;
@@ -15,11 +19,8 @@ public class TermSubClassPair {
         return superTid;
     }
 
-    public TermSubClassPair(TermId tidSub, TermId tidSuper) {
+    public SubClassTermPair(TermId tidSub, TermId tidSuper) {
         subTid=tidSub;
         superTid=tidSuper;
-
     }
-
-
 }

--- a/hpowbcore/src/main/java/org/monarchinitiative/hpoworkbench/io/HPOAnnotationParser.java
+++ b/hpowbcore/src/main/java/org/monarchinitiative/hpoworkbench/io/HPOAnnotationParser.java
@@ -9,16 +9,15 @@ import org.monarchinitiative.phenol.io.obo.hpo.HpoDiseaseAnnotationParser;
 
 
 import java.io.File;
-import java.util.ArrayList;
 import java.util.Map;
 
 /**
- * Use <a href="https://github.com/Phenomics/ontolib">ontolib</a> to parse the HPO Annotation file.
- * called {@code phenotype_annotation.tab}.
+ * Use phenol to parse the HPO Annotation file.
+ * called {@code phenotype.hpoa}.
  */
 public class HPOAnnotationParser {
     private static Logger LOGGER = Logger.getLogger(HPOAnnotationParser.class.getName());
-    private Map<String,HpoDisease> disdeasenMap =null;
+    private Map<String,HpoDisease> diseaseMap =null;
     private final  HpoOntology ontology;
     private final String annotPath;
 
@@ -29,13 +28,12 @@ public class HPOAnnotationParser {
         parse();
     }
 
-    public Map<String, HpoDisease> getDisdeaseMap() {
-        return disdeasenMap;
+    public Map<String, HpoDisease> getDiseaseMap() {
+        return diseaseMap;
     }
 
     private void parse() throws PhenolException{
-        File inputFile = new File(annotPath);
         HpoDiseaseAnnotationParser parser = new HpoDiseaseAnnotationParser(annotPath,ontology);
-        disdeasenMap =parser.parse();
+        diseaseMap =parser.parse();
     }
 }

--- a/hpowbcore/src/test/java/org/monarchinitiative/hpoworkbench/annotation/AnnotationMergerTest.java
+++ b/hpowbcore/src/test/java/org/monarchinitiative/hpoworkbench/annotation/AnnotationMergerTest.java
@@ -54,19 +54,19 @@ public class AnnotationMergerTest {
         HPOParser parser = new HPOParser(hpoPath);
         ontology = parser.getHPO();
         // Make an ORPHANET disease
-        List<HpoAnnotation> orpha = ImmutableList.of(new HpoAnnotation("HP:0002808"),
-                new HpoAnnotation("HP:0002650"),
-                new HpoAnnotation("HP:0003103"),
-                new HpoAnnotation("HP:0011001"),
-                new HpoAnnotation("HP:0003312"),
-                new HpoAnnotation("HP:0100861")
+        List<HpoAnnotation> orpha = ImmutableList.of( HpoAnnotation.parseTerm("HP:0002808"),
+                HpoAnnotation.parseTerm("HP:0002650"),
+                HpoAnnotation.parseTerm("HP:0003103"),
+                HpoAnnotation.parseTerm("HP:0011001"),
+                HpoAnnotation.parseTerm("HP:0003312"),
+                HpoAnnotation.parseTerm("HP:0100861")
                 );
         Osteomesopyknosis_ORPHANET = makeHpoDisease("Osteomesopyknosis","ORPHA","2777",orpha);
         // Make an OMIM disease
-        List<HpoAnnotation> omim = ImmutableList.of(new HpoAnnotation("HP:0000006"),
-                new HpoAnnotation("HP:0000789"),
-                new HpoAnnotation("HP:0011001"),
-                new HpoAnnotation("HP:0003419")
+        List<HpoAnnotation> omim = ImmutableList.of(HpoAnnotation.parseTerm("HP:0000006"),
+                HpoAnnotation.parseTerm("HP:0000789"),
+                HpoAnnotation.parseTerm("HP:0011001"),
+                HpoAnnotation.parseTerm("HP:0003419")
         );
         OSTEOMESOPYKNOSIS_OMIM = makeHpoDisease("OSTEOMESOPYKNOSIS","OMIM","166450",omim);
         setupCCAIDCMS();
@@ -81,51 +81,51 @@ public class AnnotationMergerTest {
      */
     private static void setupCCAIDCMS(){
         List<HpoAnnotation> orpha = new ArrayList<>();
-        //orpha.add(new HpoAnnotation("HP: "));
-        orpha.add(new HpoAnnotation("HP:0000426"));
-        orpha.add(new HpoAnnotation("HP:0000175"));
-        orpha.add(new HpoAnnotation("HP:0000612"));
-        orpha.add(new HpoAnnotation("HP:0000494"));
-        orpha.add(new HpoAnnotation("HP:0000218"));
-        orpha.add(new HpoAnnotation("HP:0000348"));
-        orpha.add(new HpoAnnotation("HP:0000453"));
-        orpha.add(new HpoAnnotation("HP:0000588"));
-        orpha.add(new HpoAnnotation("HP:0001629"));
-        orpha.add(new HpoAnnotation("HP:0001643"));
-        orpha.add(new HpoAnnotation("HP:0000407"));
-        orpha.add(new HpoAnnotation("HP:0000369"));
-        orpha.add(new HpoAnnotation("HP:0000378"));
-        orpha.add(new HpoAnnotation("HP:0000639"));
-        orpha.add(new HpoAnnotation("HP:0001274"));
-        orpha.add(new HpoAnnotation("HP:0001249"));
-        orpha.add(new HpoAnnotation("HP:0000767"));
-        orpha.add(new HpoAnnotation("HP:0000278"));
-        orpha.add(new HpoAnnotation("HP:0002650"));
-        orpha.add(new HpoAnnotation("HP:0000256"));
-        orpha.add(new HpoAnnotation("HP:0000470"));
-        orpha.add(new HpoAnnotation("HP:0004322"));
+        //orpha.add(HpoAnnotation.parseTerm("HP: "));
+        orpha.add(HpoAnnotation.parseTerm("HP:0000426"));
+        orpha.add(HpoAnnotation.parseTerm("HP:0000175"));
+        orpha.add(HpoAnnotation.parseTerm("HP:0000612"));
+        orpha.add(HpoAnnotation.parseTerm("HP:0000494"));
+        orpha.add(HpoAnnotation.parseTerm("HP:0000218"));
+        orpha.add(HpoAnnotation.parseTerm("HP:0000348"));
+        orpha.add(HpoAnnotation.parseTerm("HP:0000453"));
+        orpha.add(HpoAnnotation.parseTerm("HP:0000588"));
+        orpha.add(HpoAnnotation.parseTerm("HP:0001629"));
+        orpha.add(HpoAnnotation.parseTerm("HP:0001643"));
+        orpha.add(HpoAnnotation.parseTerm("HP:0000407"));
+        orpha.add(HpoAnnotation.parseTerm("HP:0000369"));
+        orpha.add(HpoAnnotation.parseTerm("HP:0000378"));
+        orpha.add(HpoAnnotation.parseTerm("HP:0000639"));
+        orpha.add(HpoAnnotation.parseTerm("HP:0001274"));
+        orpha.add(HpoAnnotation.parseTerm("HP:0001249"));
+        orpha.add(HpoAnnotation.parseTerm("HP:0000767"));
+        orpha.add(HpoAnnotation.parseTerm("HP:0000278"));
+        orpha.add(HpoAnnotation.parseTerm("HP:0002650"));
+        orpha.add(HpoAnnotation.parseTerm("HP:0000256"));
+        orpha.add(HpoAnnotation.parseTerm("HP:0000470"));
+        orpha.add(HpoAnnotation.parseTerm("HP:0004322"));
         CCAIDCMS_ORPHA=makeHpoDisease("CCAIDCMS","ORHPA","52055",orpha);
 
         List<HpoAnnotation> mim = new ArrayList<>();
-        mim.add(new HpoAnnotation("HP:0001419"));
-        mim.add(new HpoAnnotation("HP:0000612"));
-        mim.add(new HpoAnnotation("HP:0000494"));
-        mim.add(new HpoAnnotation("HP:0000218"));
-        mim.add(new HpoAnnotation("HP:0000475"));
-        mim.add(new HpoAnnotation("HP:0000348"));
-        mim.add(new HpoAnnotation("HP:0000588"));
-        mim.add(new HpoAnnotation("HP:0000407"));
-        mim.add(new HpoAnnotation("HP:0000369"));
-        mim.add(new HpoAnnotation("HP:0000378"));
-        mim.add(new HpoAnnotation("HP:0000505"));
-        mim.add(new HpoAnnotation("HP:0001274"));
-        mim.add(new HpoAnnotation("HP:0001249"));
-        mim.add(new HpoAnnotation("HP:0000767"));
-        mim.add(new HpoAnnotation("HP:0000278"));
-        mim.add(new HpoAnnotation("HP:0002650"));
-        mim.add(new HpoAnnotation("HP:0000256"));
-        mim.add(new HpoAnnotation("HP:0000470"));
-        mim.add(new HpoAnnotation("HP:0004322"));
+        mim.add(HpoAnnotation.parseTerm("HP:0001419"));
+        mim.add(HpoAnnotation.parseTerm("HP:0000612"));
+        mim.add(HpoAnnotation.parseTerm("HP:0000494"));
+        mim.add(HpoAnnotation.parseTerm("HP:0000218"));
+        mim.add(HpoAnnotation.parseTerm("HP:0000475"));
+        mim.add(HpoAnnotation.parseTerm("HP:0000348"));
+        mim.add(HpoAnnotation.parseTerm("HP:0000588"));
+        mim.add(HpoAnnotation.parseTerm("HP:0000407"));
+        mim.add(HpoAnnotation.parseTerm("HP:0000369"));
+        mim.add(HpoAnnotation.parseTerm("HP:0000378"));
+        mim.add(HpoAnnotation.parseTerm("HP:0000505"));
+        mim.add(HpoAnnotation.parseTerm("HP:0001274"));
+        mim.add(HpoAnnotation.parseTerm("HP:0001249"));
+        mim.add(HpoAnnotation.parseTerm("HP:0000767"));
+        mim.add(HpoAnnotation.parseTerm("HP:0000278"));
+        mim.add(HpoAnnotation.parseTerm("HP:0002650"));
+        mim.add(HpoAnnotation.parseTerm("HP:0000256"));
+        mim.add(HpoAnnotation.parseTerm("HP:0000470"));
+        mim.add(HpoAnnotation.parseTerm("HP:0004322"));
         CCAIDCMS_OMIM = makeHpoDisease("CCAIDCMS","OMIM","300472",mim);
 
 

--- a/hpowbgui/src/main/java/org/monarchinitiative/hpoworkbench/HpoWorkbenchGuiModule.java
+++ b/hpowbgui/src/main/java/org/monarchinitiative/hpoworkbench/HpoWorkbenchGuiModule.java
@@ -7,6 +7,7 @@ import javafx.application.Platform;
 import javafx.stage.Stage;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.monarchinitiative.hpoworkbench.controller.HpoController;
 import org.monarchinitiative.hpoworkbench.controller.MainController;
 import org.monarchinitiative.hpoworkbench.controller.MondoController;
 import org.monarchinitiative.hpoworkbench.controller.StatusController;
@@ -82,6 +83,8 @@ public final class HpoWorkbenchGuiModule extends AbstractModule {
 
         bind(MondoController.class).asEagerSingleton();
 
+        bind(HpoController.class).asEagerSingleton();
+
         // ------ CONTROLLERS ------
     }
 
@@ -136,7 +139,7 @@ public final class HpoWorkbenchGuiModule extends AbstractModule {
         Properties properties = new Properties();
         if (propertiesPath.isFile()) {
             try {
-                LOGGER.trace("Loading app properties from {}", propertiesPath.getAbsolutePath());
+                LOGGER.info("Loading app properties from {}", propertiesPath.getAbsolutePath());
                 properties.load(new FileReader(propertiesPath));
             } catch (IOException e) {
                 LOGGER.warn(e);
@@ -144,7 +147,7 @@ public final class HpoWorkbenchGuiModule extends AbstractModule {
         } else {
             try {
                 URL propertiesUrl = Main.class.getResource("/" + PlatformUtil.HPO_WORKBENCH_SETTINGS_FILENAME);
-                LOGGER.trace("Trying to load app properties from bundled file {}", propertiesUrl.getPath());
+                LOGGER.info("Loading app properties from bundled file {}", propertiesUrl.getPath());
                 properties.load(Main.class.getResourceAsStream("/" + PlatformUtil.HPO_WORKBENCH_SETTINGS_FILENAME));
             } catch (IOException e) {
                 LOGGER.warn(e);
@@ -177,10 +180,12 @@ public final class HpoWorkbenchGuiModule extends AbstractModule {
     @Named("hpoWorkbenchDir")
     private File hpoWorkbenchDir() {
         File workbenchdir = PlatformUtil.getHpoWorkbenchDir();
-        if (workbenchdir.isDirectory() || workbenchdir.mkdirs())
-            return workbenchdir;
-        else
-            LOGGER.fatal("Unable to create HPO workbench directory at {}", workbenchdir);
+        if (workbenchdir != null) {
+            if (workbenchdir.isDirectory() || workbenchdir.mkdirs())
+                return workbenchdir;
+        }
+
+        LOGGER.fatal("Unable to create HPO workbench directory at {}", workbenchdir);
         Platform.exit();
         return null; // shouldn't get here, but we need to return something
     }

--- a/hpowbgui/src/main/java/org/monarchinitiative/hpoworkbench/HpoWorkbenchGuiModule.java
+++ b/hpowbgui/src/main/java/org/monarchinitiative/hpoworkbench/HpoWorkbenchGuiModule.java
@@ -20,6 +20,7 @@ import org.monarchinitiative.hpoworkbench.io.MondoParser;
 import org.monarchinitiative.hpoworkbench.io.UTF8Control;
 import org.monarchinitiative.hpoworkbench.resources.OptionalResources;
 import org.monarchinitiative.phenol.base.PhenolException;
+import org.monarchinitiative.phenol.formats.hpo.HpoDisease;
 import org.monarchinitiative.phenol.formats.hpo.HpoOntology;
 import org.monarchinitiative.phenol.io.obo.hpo.HpoDiseaseAnnotationParser;
 
@@ -30,6 +31,7 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.net.URL;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Properties;
 import java.util.ResourceBundle;
 import java.util.concurrent.ExecutorService;
@@ -121,7 +123,11 @@ public final class HpoWorkbenchGuiModule extends AbstractModule {
             if (hpoontology!=null) {
                 HpoDiseaseAnnotationParser annotparser = new HpoDiseaseAnnotationParser(annots,hpoontology);
                 try {
-                    optionalResources.setDisease2annotationMap(annotparser.parse());
+                    Map<String,HpoDisease> diseasemap =annotparser.parse();
+                    for (String d : diseasemap.keySet()) {
+                        System.err.print(d);
+                    }
+                    optionalResources.setDisease2annotationMap(diseasemap);
                 } catch (PhenolException pe) {
                     PopUps.showException("Error","Could not parse annotation file", pe);
                 }

--- a/hpowbgui/src/main/java/org/monarchinitiative/hpoworkbench/HpoWorkbenchGuiModule.java
+++ b/hpowbgui/src/main/java/org/monarchinitiative/hpoworkbench/HpoWorkbenchGuiModule.java
@@ -110,7 +110,7 @@ public final class HpoWorkbenchGuiModule extends AbstractModule {
             optionalResources.setDirectAnnotMap(parser.getDirectAnnotMap());
             optionalResources.setIndirectAnnotMap(parser.getIndirectAnnotMap());
         }
-        String mondoOboFile = properties.getProperty("mono.obo.path");
+        String mondoOboFile = properties.getProperty("mondo.obo.path");
         if (mondoOboFile!=null && new File(mondoOboFile).isFile()) {
             LOGGER.trace("Loading MONDO ontology from {}",mondoOboFile);
             try {

--- a/hpowbgui/src/main/java/org/monarchinitiative/hpoworkbench/HpoWorkbenchGuiModule.java
+++ b/hpowbgui/src/main/java/org/monarchinitiative/hpoworkbench/HpoWorkbenchGuiModule.java
@@ -4,6 +4,7 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.google.inject.name.Names;
 import javafx.application.Platform;
+import javafx.beans.property.Property;
 import javafx.stage.Stage;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -93,6 +94,11 @@ public final class HpoWorkbenchGuiModule extends AbstractModule {
     private OptionalResources optionalResources(Properties properties) {
         OptionalResources optionalResources = new OptionalResources();
 
+        System.err.println("OPTIMAL RESOURCES");
+        for (String p :properties.stringPropertyNames()) {
+            System.err.println("P="+p+": "+properties.getProperty(p));
+        }
+
         // load ontology & annotation file, if available
         String obofile = properties.getProperty("hpo.obo.path");
         if (obofile != null && new File(obofile).isFile()) {
@@ -111,6 +117,7 @@ public final class HpoWorkbenchGuiModule extends AbstractModule {
             optionalResources.setIndirectAnnotMap(parser.getIndirectAnnotMap());
         }
         String mondoOboFile = properties.getProperty("mondo.obo.path");
+        System.err.println("MODNO = "+mondoOboFile);
         if (mondoOboFile!=null && new File(mondoOboFile).isFile()) {
             LOGGER.trace("Loading MONDO ontology from {}",mondoOboFile);
             try {

--- a/hpowbgui/src/main/java/org/monarchinitiative/hpoworkbench/controller/HpoController.java
+++ b/hpowbgui/src/main/java/org/monarchinitiative/hpoworkbench/controller/HpoController.java
@@ -1,0 +1,881 @@
+package org.monarchinitiative.hpoworkbench.controller;
+
+import com.google.inject.Inject;
+import com.google.inject.name.Named;
+import javafx.application.Platform;
+import javafx.beans.binding.BooleanBinding;
+import javafx.beans.value.ChangeListener;
+import javafx.beans.value.ObservableValue;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.concurrent.Worker;
+import javafx.fxml.FXML;
+import javafx.scene.control.*;
+import javafx.scene.web.WebEngine;
+import javafx.scene.web.WebView;
+import javafx.stage.FileChooser;
+import javafx.stage.Stage;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.monarchinitiative.hpoworkbench.excel.HierarchicalExcelExporter;
+import org.monarchinitiative.hpoworkbench.excel.Hpo2ExcelExporter;
+import org.monarchinitiative.hpoworkbench.exception.HPOException;
+import org.monarchinitiative.hpoworkbench.exception.HPOWorkbenchException;
+import org.monarchinitiative.hpoworkbench.github.GitHubLabelRetriever;
+import org.monarchinitiative.hpoworkbench.github.GitHubPoster;
+import org.monarchinitiative.hpoworkbench.gui.GitHubPopup;
+import org.monarchinitiative.hpoworkbench.gui.PopUps;
+import org.monarchinitiative.hpoworkbench.gui.WidthAwareTextFields;
+import org.monarchinitiative.hpoworkbench.model.DiseaseModel;
+import org.monarchinitiative.hpoworkbench.model.Model;
+import org.monarchinitiative.hpoworkbench.resources.OptionalResources;
+import org.monarchinitiative.phenol.formats.hpo.HpoOntology;
+import org.monarchinitiative.phenol.formats.hpo.HpoTerm;
+import org.monarchinitiative.phenol.ontology.data.ImmutableTermId;
+import org.monarchinitiative.phenol.ontology.data.TermId;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+import org.w3c.dom.events.EventListener;
+import org.w3c.dom.events.EventTarget;
+
+import java.io.File;
+import java.util.*;
+import java.util.function.Consumer;
+
+import static org.monarchinitiative.hpoworkbench.controller.MainController.mode.*;
+import static org.monarchinitiative.phenol.ontology.algo.OntologyAlgorithm.*;
+
+/**
+ * Controller for the {@link Tab} that displays HPO. The {@link Tab} is a part of the {@link MainController}
+ *
+ * @author <a href="mailto:daniel.danis@jax.org">Daniel Danis</a>
+ * @version 0.1.12
+ * @since 0.1
+ */
+
+public final class HpoController {
+
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    private static final String EVENT_TYPE_CLICK = "click";
+
+    private static final String EVENT_TYPE_MOUSEOVER = "mouseover";
+
+    private static final String EVENT_TYPE_MOUSEOUT = "mouseclick";
+
+    private final Stage primaryStage;
+
+    private final OptionalResources optionalResources;
+
+    /** Current behavior of HPO Workbench. See {@link MainController.mode}. */
+    private MainController.mode currentMode = MainController.mode.BROWSE_HPO;
+
+    @FXML
+    private RadioButton hpoTermRadioButton;
+
+    @FXML
+    private RadioButton diseaseRadioButton;
+
+    @FXML
+    private RadioButton newAnnotationRadioButton;
+
+    @FXML
+    private TextField searchTextField;
+
+    @FXML
+    private Button goButton;
+
+    @FXML
+    private TreeView<HpoTermWrapper> ontologyTreeView;
+
+    /** WebView for displaying details of the Term that is selected in the {@link #ontologyTreeView}. */
+    @FXML
+    private WebView infoWebView;
+
+    /** WebEngine backing up the {@link #infoWebView}. */
+    private WebEngine infoWebEngine;
+
+    @FXML
+    private Button exportHierarchicalSummaryButton;
+
+    @FXML
+    private Button exportToExcelButton;
+
+    @FXML
+    private Button suggestCorrectionToTermButton;
+
+    @FXML
+    private Button suggestNewChildTermButton;
+
+    @FXML
+    private Button suggestNewAnnotationButton;
+
+    @FXML
+    private Button reportMistakenAnnotationButton;
+
+    @FXML
+    private RadioButton allDatabaseButton;
+
+    @FXML
+    private RadioButton orphanetButton;
+
+    @FXML
+    private RadioButton omimButton;
+
+    @FXML
+    private RadioButton decipherButton;
+
+    /** Current disease shown in the browser. Any suggested changes will refer to this disease. */
+    private DiseaseModel selectedDisease = null;
+
+    /** This determines which disease as shown (OMIM, Orphanet, DECIPHER, or all). Default: ALL. */
+    private DiseaseModel.database selectedDatabase = DiseaseModel.database.ALL;
+
+    /** Key: a term name such as "Myocardial infarction"; value: the corresponding HPO id as a {@link TermId}. */
+    private Map<String, TermId> labelsAndHpoIds = new HashMap<>();
+
+    private Model model;
+
+    /** The term that is currently selected in the Browser window. */
+    private HpoTerm selectedTerm = null;
+
+    /** Users can create a github issue. Username and password will be stored for the current session only. */
+    private String githubUsername = null;
+
+    private String githubPassword;
+
+    @Inject
+    public HpoController(OptionalResources optionalResources, @Named("mainWindow") Stage primaryStage) {
+        this.optionalResources = optionalResources;
+        this.primaryStage = primaryStage;
+    }
+
+    @FXML
+    public void goButtonAction() {
+        if (currentMode.equals(BROWSE_DISEASE)) {
+            DiseaseModel dmod = model.getDiseases().get(searchTextField.getText());
+            if (dmod == null) return;
+            updateDescriptionToDiseaseModel(dmod);
+            selectedDisease = dmod;
+            searchTextField.clear();
+        } else if (currentMode.equals(MainController.mode.BROWSE_HPO)) {
+            TermId id = labelsAndHpoIds.get(searchTextField.getText());
+            if (id == null) return; // button was clicked while field was empty, no need to do anything
+            expandUntilTerm(optionalResources.getHpoOntology().getTermMap().get(id));
+            searchTextField.clear();
+        } else if (currentMode == MainController.mode.NEW_ANNOTATION) {
+            TermId id = labelsAndHpoIds.get(searchTextField.getText());
+            if (id == null) return; // button was clicked while field was empty, no need to do anything
+            expandUntilTerm(optionalResources.getHpoOntology().getTermMap().get(id));
+            searchTextField.clear();
+        }
+    }
+
+    @FXML
+    public void exportHierarchicalSummary() {
+        if (selectedTerm == null) {
+            selectedTerm = getSelectedTerm().getValue().term;
+        }
+        if (selectedTerm == null) { // should only happen if the user hasn't selected anything at all.
+            LOGGER.error("Select a term before exporting hierarchical summary TODO show error window");
+            PopUps.showInfoMessage("Please select an HPO term in order to export a term with its subhierarchy",
+                    "Error: No HPO Term selected");
+            return; // to do throw exceptio
+        }
+        selectedTerm = getSelectedTerm().getValue().term;
+        FileChooser chooser = new FileChooser();
+        chooser.setTitle("Export HPO as Excel-format file");
+        FileChooser.ExtensionFilter extFilter = new FileChooser.ExtensionFilter("Excel file (*.xlsx)", "*.xlsx");
+        chooser.getExtensionFilters().add(extFilter);
+        chooser.setInitialFileName(String.format("%s.xlsx", selectedTerm.getName()));
+        File f = chooser.showSaveDialog(null);
+        if (f != null) {
+            String path = f.getAbsolutePath();
+            LOGGER.trace(String.format("Setting path to hierarchical export file to %s", path));
+        } else {
+            LOGGER.error("Unable to obtain path to Excel export file");
+            return;
+        }
+        LOGGER.trace(String.format("Exporting hierarchical summary starting from term %s", selectedTerm.toString()));
+        HierarchicalExcelExporter exporter = new HierarchicalExcelExporter(model.getOntology(), selectedTerm);
+        try {
+            exporter.exportToExcel(f.getAbsolutePath());
+        } catch (HPOException e) {
+            PopUps.showException("Error", "could not export excel file", e);
+        }
+    }
+
+    @FXML
+    public void exportToExcel() {
+        LOGGER.trace("exporting to excel");
+        FileChooser chooser = new FileChooser();
+        chooser.setTitle("Export HPO as Excel-format file");
+        FileChooser.ExtensionFilter extFilter = new FileChooser.ExtensionFilter("Excel file (*.xlsx)", "*.xlsx");
+        chooser.getExtensionFilters().add(extFilter);
+        chooser.setInitialFileName("hpo.xlsx");
+        File f = chooser.showSaveDialog(null);
+        if (f != null) {
+            String path = f.getAbsolutePath();
+            LOGGER.trace(String.format("Setting path to LOINC Core Table file to %s", path));
+            Hpo2ExcelExporter exporter = new Hpo2ExcelExporter(model.getOntology());
+            exporter.exportToExcelFile(path);
+        } else {
+            LOGGER.error("Unable to obtain path to Excel export file");
+        }
+    }
+
+    @FXML
+    public void suggestCorrectionToTerm() {
+        if (getSelectedTerm() == null) {
+            LOGGER.error("Select a term before creating GitHub issue");
+            PopUps.showInfoMessage("Please select an HPO term before creating GitHub issue",
+                    "Error: No HPO Term selected");
+            return;
+        } else {
+            selectedTerm = getSelectedTerm().getValue().term;
+        }
+        selectedTerm = getSelectedTerm().getValue().term;
+        GitHubPopup popup = new GitHubPopup(selectedTerm);
+        initializeGitHubLabelsIfNecessary();
+        popup.setLabels(model.getGithublabels());
+        popup.setupGithubUsernamePassword(githubUsername, githubPassword);
+        popup.displayWindow(primaryStage);
+        String githubissue = popup.retrieveGitHubIssue();
+        if (popup.wasCancelled()) {
+            return;
+        }
+        if (githubissue == null) {
+            LOGGER.trace("got back null GitHub issue");
+            return;
+        }
+        String title = String.format("Correction to term %s", selectedTerm.getName());
+        postGitHubIssue(githubissue, title, popup.getGitHubUserName(), popup.getGitHubPassWord(), popup.getGitHubLabels());
+    }
+
+    @FXML
+    public void suggestNewChildTerm() {
+        if (getSelectedTerm() == null) {
+            LOGGER.error("Select a term before creating GitHub issue");
+            PopUps.showInfoMessage("Please select an HPO term before creating GitHub issue",
+                    "Error: No HPO Term selected");
+            return;
+        } else {
+            selectedTerm = getSelectedTerm().getValue().term;
+        }
+        GitHubPopup popup = new GitHubPopup(selectedTerm, true);
+        initializeGitHubLabelsIfNecessary();
+        popup.setLabels(model.getGithublabels());
+        popup.setupGithubUsernamePassword(githubUsername, githubPassword);
+        popup.displayWindow(primaryStage);
+        String githubissue = popup.retrieveGitHubIssue();
+        if (githubissue == null) {
+            LOGGER.trace("got back null github issue");
+            return;
+        }
+        String title = String.format("Suggesting new child term of \"%s\"", selectedTerm.getName());
+        postGitHubIssue(githubissue, title, popup.getGitHubUserName(), popup.getGitHubPassWord(), popup.getGitHubLabels());
+    }
+
+    @FXML
+    public void suggestNewAnnotation() {
+        if (getSelectedTerm() == null) {
+            LOGGER.error("Select a term before creating GitHub issue");
+            PopUps.showInfoMessage("Please select an HPO term before creating GitHub issue",
+                    "Error: No HPO Term selected");
+            return;
+        } else {
+            selectedTerm = getSelectedTerm().getValue().term;
+        }
+        if (!currentMode.equals(MainController.mode.NEW_ANNOTATION)) {
+            PopUps.showInfoMessage("Please select a disease and then a new HPO term before using this option",
+                    "Error: No disease selected");
+            return;
+        }
+        selectedTerm = getSelectedTerm().getValue().term;
+        if (selectedDisease == null) {
+            PopUps.showInfoMessage("Please select a disease and then a new HPO term before using this option",
+                    "Error: No disease selected");
+            return;
+        }
+        GitHubPopup popup = new GitHubPopup(selectedTerm, selectedDisease);
+        initializeGitHubLabelsIfNecessary();
+        popup.setLabels(model.getGithublabels());
+        popup.setupGithubUsernamePassword(githubUsername, githubPassword);
+        popup.displayWindow(primaryStage);
+        String githubissue = popup.retrieveGitHubIssue();
+        if (githubissue == null) {
+            LOGGER.trace("got back null GitHub issue");
+            return;
+        }
+        String title = String.format("New annotation suggestion for %s", selectedDisease.getDiseaseName());
+        postGitHubIssue(githubissue, title, popup.getGitHubUserName(), popup.getGitHubPassWord(), popup.getGitHubLabels());
+    }
+
+    @FXML
+    public void reportMistakenAnnotation() {
+        if (getSelectedTerm() == null) {
+            LOGGER.error("Select a term before creating GitHub issue");
+            PopUps.showInfoMessage("Please select an HPO term before creating GitHub issue",
+                    "Error: No HPO Term selected");
+            return;
+        } else {
+            selectedTerm = getSelectedTerm().getValue().term;
+        }
+        if (!currentMode.equals(MainController.mode.NEW_ANNOTATION)) {
+            PopUps.showInfoMessage("Please select a disease and then a new HPO term before using this option",
+                    "Error: No disease selected");
+            return;
+        }
+        selectedTerm = getSelectedTerm().getValue().term;
+        if (selectedDisease == null) {
+            PopUps.showInfoMessage("Please select a disease and then a new HPO term before using this option",
+                    "Error: No disease selected");
+            return;
+        }
+        GitHubPopup popup = new GitHubPopup(selectedTerm, selectedDisease, true);
+        initializeGitHubLabelsIfNecessary();
+        popup.setLabels(model.getGithublabels());
+        popup.setupGithubUsernamePassword(githubUsername, githubPassword);
+        popup.displayWindow(primaryStage);
+        String githubissue = popup.retrieveGitHubIssue();
+        if (githubissue == null) {
+            LOGGER.trace("got back null GitHub issue");
+            return;
+        }
+        String title = String.format("Erroneous annotation for %s", selectedDisease.getDiseaseName());
+        postGitHubIssue(githubissue, title, popup.getGitHubUserName(), popup.getGitHubPassWord());
+    }
+
+
+    public void initialize() {
+                //logger.trace("initialize");
+//        // This action will be run after user approves a PhenotypeTerm in the ontologyTreePane
+//        Consumer<HpoTerm> addHook = (ph -> logger.trace(String.format("Hook for %s", ph.getName())));
+
+        initRadioButtons();
+
+        // this binding evaluates to true, if ontology or annotations files are missing (null)
+        BooleanBinding hpoResourceMissing = optionalResources.hpoResourceMissing();
+
+        hpoTermRadioButton.disableProperty().bind(hpoResourceMissing);
+        diseaseRadioButton.disableProperty().bind(hpoResourceMissing);
+        newAnnotationRadioButton.disableProperty().bind(hpoResourceMissing);
+
+        searchTextField.disableProperty().bind(hpoResourceMissing);
+        goButton.disableProperty().bind(hpoResourceMissing);
+        ontologyTreeView.disableProperty().bind(hpoResourceMissing);
+
+        exportHierarchicalSummaryButton.disableProperty().bind(hpoResourceMissing);
+        exportToExcelButton.disableProperty().bind(hpoResourceMissing);
+        suggestCorrectionToTermButton.disableProperty().bind(hpoResourceMissing);
+        suggestNewChildTermButton.disableProperty().bind(hpoResourceMissing);
+        suggestNewAnnotationButton.disableProperty().bind(hpoResourceMissing);
+        reportMistakenAnnotationButton.disableProperty().bind(hpoResourceMissing);
+
+        hpoResourceMissing.addListener(((observable, oldValue, newValue) -> {
+            if (!newValue) { // nothing is missing anymore
+                activate();
+            } else { // invalidate model and anything in the background. Controls should be disabled automatically
+                deactivate();
+            }
+        }));
+
+
+        if (!hpoResourceMissing.get()) {
+            activate();
+        }
+    }
+
+    private void activate() {
+        initTree(optionalResources.getHpoOntology(), k -> System.out.println("Consumed " + k));
+        this.model = new Model(optionalResources.getHpoOntology(), optionalResources.getIndirectAnnotMap(),
+                optionalResources.getDirectAnnotMap());
+    }
+
+    private void deactivate() {
+        initTree(null, k -> System.out.println("Consumed " + k));
+        this.model = new Model(null, null, null);
+    }
+
+
+    /**
+     * Update content of the {@link #infoWebView} with currently selected {@link HpoTerm}.
+     * The function is called when the user is on an HPO Term page and selects a link to
+     * a disease.
+     *
+     * @param dmodel currently selected {@link TreeItem} containing {@link HpoTerm}
+     */
+    private void updateDescriptionToDiseaseModel(DiseaseModel dmodel) {
+        LOGGER.trace("TOP OF updateDescriptionToDiseaseModel");
+        String dbName = dmodel.getDiseaseDbAndId();
+        String diseaseName = dmodel.getDiseaseName();
+        List<HpoTerm> annotatingTerms = model.getAnnotationTermsForDisease(dmodel);
+        String content = HpoHtmlPageGenerator.getDiseaseHTML(dbName, diseaseName, annotatingTerms, optionalResources
+                .getHpoOntology());
+        infoWebEngine.loadContent(content);
+        infoWebEngine.getLoadWorker().stateProperty().addListener(new ChangeListener<Worker.State>() {
+            @Override
+            public void changed(ObservableValue ov, Worker.State oldState, Worker.State newState) {
+                LOGGER.trace("TOP OF CHANGED updateDescriptionToDiseaseModel");
+                if (newState == Worker.State.SUCCEEDED) {
+                    org.w3c.dom.events.EventListener listener = new EventListener() {
+                        @Override
+                        public void handleEvent(org.w3c.dom.events.Event ev) {
+                            String domEventType = ev.getType();
+                            //System.err.println("EventType from updateToDisease: " + domEventType);
+                            if (domEventType.equals(EVENT_TYPE_CLICK)) {
+                                String href = ((Element) ev.getTarget()).getAttribute("href");
+                                if (href.equals("http://www.human-phenotype-ontology.org")) {
+                                    return; // the external link is taken care of by the Webengine
+                                    // therefore, we do not need to do anything special here
+                                }
+                                // The following line is needed because sometimes we get multiple click events
+                                // if the user clicks once and some appear to be for the "wrong" link type.
+                                if (!href.startsWith("HP:")) {
+                                    return;
+                                }
+                                TermId tid = ImmutableTermId.constructWithPrefix(href);
+                                HpoTerm term = optionalResources.getHpoOntology().getTermMap().get(tid);
+                                if (term == null) {
+                                    LOGGER.error(String.format("Could not construct term  from termid \"%s\"", tid.getIdWithPrefix()));
+                                    return;
+                                }
+                                // set the tree on the left to our new term
+                                expandUntilTerm(term);
+                                // update the Webview browser
+                                LOGGER.trace("ABOUT TO UPDATE DESCRIPTION FOR " + term.getName());
+                                updateDescription(new HpoTermTreeItem(new HpoTermWrapper(term)));
+                                searchTextField.clear();
+                                currentMode = MainController.mode.BROWSE_HPO;
+                                hpoTermRadioButton.setSelected(true);
+                            }
+                        }
+                    };
+
+                    Document doc = infoWebView.getEngine().getDocument();
+                    NodeList nodeList = doc.getElementsByTagName("a");
+                    for (int i = 0; i < nodeList.getLength(); i++) {
+                        ((EventTarget) nodeList.item(i)).addEventListener(EVENT_TYPE_CLICK, listener, false);
+                        //((EventTarget) nodeList.item(i)).addEventListener(EVENT_TYPE_MOUSEOVER, listener, false);
+                        //((EventTarget) nodeList.item(i)).addEventListener(EVENT_TYPE_MOUSEOVER, listener, false);
+                    }
+                }
+            }
+        });
+    }
+
+    /**
+     * Find the path from the root term to given {@link HpoTerm}, expand the tree and set the selection model of the
+     * TreeView to the term position.
+     *
+     * @param term {@link HpoTerm} to be displayed
+     */
+    private void expandUntilTerm(HpoTerm term) {
+        // logger.trace("expand until term " + term.toString());
+        switchToMode(BROWSE_HPO);
+        if (existsPathFromRoot(term)) {
+            // find root -> term path through the tree
+            Stack<HpoTerm> termStack = new Stack<>();
+            termStack.add(term);
+            Set<HpoTerm> parents = getTermParents(term);
+            while (parents.size() != 0) {
+                HpoTerm parent = parents.iterator().next();
+                termStack.add(parent);
+                parents = getTermParents(parent);
+            }
+
+            // expand tree nodes in top -> down direction
+            List<TreeItem<HpoTermWrapper>> children = ontologyTreeView.getRoot().getChildren();
+            termStack.pop(); // get rid of 'All' node which is hidden
+            TreeItem<HpoTermWrapper> target = ontologyTreeView.getRoot();
+            while (!termStack.empty()) {
+                HpoTerm current = termStack.pop();
+                for (TreeItem<HpoTermWrapper> child : children) {
+                    if (child.getValue().term.equals(current)) {
+                        child.setExpanded(true);
+                        target = child;
+                        children = child.getChildren();
+                        break;
+                    }
+                }
+            }
+            ontologyTreeView.getSelectionModel().select(target);
+            ontologyTreeView.scrollTo(ontologyTreeView.getSelectionModel().getSelectedIndex());
+        } else {
+            TermId rootId = optionalResources.getHpoOntology().getRootTermId();
+            HpoTerm rootTerm = optionalResources.getHpoOntology().getTermMap().get(rootId);
+            LOGGER.warn(String.format("Unable to find the path from %s to %s", rootTerm.toString(), term.getName()));
+        }
+        selectedTerm = term;
+    }
+
+    /**
+     * Update content of the {@link #infoWebView} with currently selected {@link HpoTerm}.
+     *
+     * @param treeItem currently selected {@link TreeItem} containing {@link HpoTerm}
+     */
+    private void updateDescription(TreeItem<HpoTermWrapper> treeItem) {
+        LOGGER.trace("TOP OF UPDATE DESCRIPTION");
+        if (currentMode.equals(MainController.mode.NEW_ANNOTATION)) {
+            return;
+        }
+        if (treeItem == null)
+            return;
+
+        HpoTerm term = treeItem.getValue().term;
+        String termID = term.getId().getIdWithPrefix();
+        List<DiseaseModel> annotatedDiseases = model.getDiseaseAnnotations(termID, selectedDatabase);
+        if (annotatedDiseases == null) {
+            LOGGER.error("could not retrieve diseases for " + termID);
+        }
+        int n_descendents = 42;//getDescendents(model.getOntology(),term.getId()).size();
+        //todo--add number of descendents to HTML
+        String content = HpoHtmlPageGenerator.getHTML(term, annotatedDiseases);
+        //System.out.print(content);
+        // infoWebEngine=this.infoWebView.getEngine();
+        infoWebEngine.loadContent(content);
+        infoWebEngine.getLoadWorker().stateProperty().addListener(new ChangeListener<Worker.State>() {
+            @Override
+            public void changed(ObservableValue ov, Worker.State oldState, Worker.State newState) {
+                LOGGER.trace("TOP OF CHANGED  UPDATE DESCRIPTION");
+                if (newState == Worker.State.SUCCEEDED) {
+                    org.w3c.dom.events.EventListener listener = new EventListener() {
+                        @Override
+                        public void handleEvent(org.w3c.dom.events.Event ev) {
+                            String domEventType = ev.getType();
+                            // System.err.println("EventType FROM updateHPO: " + domEventType);
+                            if (domEventType.equals(EVENT_TYPE_CLICK)) {
+                                String href = ((Element) ev.getTarget()).getAttribute("href");
+                                // System.out.println("HREF "+href);
+                                if (href.equals("http://www.human-phenotype-ontology.org")) {
+                                    return; // the external link is taken care of by the Webengine
+                                    // therefore, we do not need to do anything special here
+                                }
+                                // The following line is necessary because sometimes multiple events are triggered
+                                // and we get a "stray" HPO-related link that does not belong here.
+                                if (href.startsWith("HP:")) return;
+                                DiseaseModel dmod = model.getDiseases().get(href);
+                                if (dmod == null) {
+                                    LOGGER.error("Link to disease model for " + href + " was null");
+                                    return;
+                                }
+                                updateDescriptionToDiseaseModel(dmod);
+                                selectedDisease = dmod;
+                                searchTextField.clear();
+                                currentMode = BROWSE_DISEASE;
+                                diseaseRadioButton.setSelected(true);
+                            }
+                        }
+                    };
+
+                    Document doc = infoWebView.getEngine().getDocument();
+                    NodeList nodeList = doc.getElementsByTagName("a");
+                    for (int i = 0; i < nodeList.getLength(); i++) {
+                        ((EventTarget) nodeList.item(i)).addEventListener(EVENT_TYPE_CLICK, listener, false);
+                        //((EventTarget) nodeList.item(i)).addEventListener(EVENT_TYPE_MOUSEOVER, listener, false);
+                        //((EventTarget) nodeList.item(i)).addEventListener(EVENT_TYPE_MOUSEOVER, listener, false);
+                    }
+                }
+            }
+        });
+
+    }
+
+    /**
+     * Initialize the ontology browser-tree in the left column of the app.
+     *
+     * @param ontology Reference to the HPO
+     * @param addHook  function hook (currently unused)
+     */
+    private void initTree(HpoOntology ontology, Consumer<HpoTerm> addHook) {
+        // populate the TreeView with top-level elements from ontology hierarchy
+        if (ontology == null) {
+            ontologyTreeView.setRoot(null);
+            return;
+        }
+        TermId rootId = ontology.getRootTermId();
+        HpoTerm rootTerm = ontology.getTermMap().get(rootId);
+        TreeItem<HpoTermWrapper> root = new HpoTermTreeItem(new HpoTermWrapper(rootTerm));
+        root.setExpanded(true);
+//        if (ontologyTreeView==null) {
+//            logger.fatal("Tree view is not initialized");
+//            return;
+//        }
+        ontologyTreeView.setShowRoot(false);
+        ontologyTreeView.setRoot(root);
+        ontologyTreeView.getSelectionModel().selectedItemProperty()
+                .addListener((observable, oldValue, newValue) -> {
+                    if (newValue == null) {
+                        LOGGER.error("New value is null");
+                        return;
+                    }
+                    HpoTermWrapper w = newValue.getValue();
+                    TreeItem item = new HpoTermTreeItem(w);
+                    updateDescription(item);
+                });
+        // create Map for lookup of the terms in the ontology based on their Name
+        ontology.getTermMap().values().forEach(term -> {
+            labelsAndHpoIds.put(term.getName(), term.getId());
+            labelsAndHpoIds.put(term.getId().getIdWithPrefix(), term.getId());
+        });
+        WidthAwareTextFields.bindWidthAwareAutoCompletion(searchTextField, labelsAndHpoIds.keySet());
+
+        // show intro message in the infoWebView
+        Platform.runLater(() -> {
+            infoWebEngine = infoWebView.getEngine();
+            infoWebEngine.loadContent("<!DOCTYPE html><html lang=\"en\"><head><meta charset=\"UTF-8\"><title>HPO tree browser</title></head>" +
+                    "<body><p>Click on HPO term in the tree browser to display additional information</p></body></html>");
+        });
+    }
+
+    private void initRadioButtons() {
+        ToggleGroup group = new ToggleGroup();
+        allDatabaseButton.setSelected(true);
+        allDatabaseButton.setToggleGroup(group);
+        omimButton.setSelected(false);
+        omimButton.setToggleGroup(group);
+        orphanetButton.setSelected(false);
+        orphanetButton.setToggleGroup(group);
+        decipherButton.setSelected(false);
+        decipherButton.setToggleGroup(group);
+        group.selectedToggleProperty().addListener(
+                (ObservableValue<? extends Toggle> ov, Toggle old_toggle, Toggle new_toggle) -> {
+                    if (group.getSelectedToggle() != null) {
+                        String userdata = (String) group.getSelectedToggle().getUserData();
+                        if (userdata == null) {
+                            LOGGER.warn("Could not retrieve user data for database radio buttons");
+                        }
+                        if (userdata.equals("orphanet"))
+                            selectedDatabase = DiseaseModel.database.ORPHANET;
+                        else if (userdata.equals("omim"))
+                            selectedDatabase = DiseaseModel.database.OMIM;
+                        else if (userdata.equals("all"))
+                            selectedDatabase = DiseaseModel.database.ALL;
+                        else if (userdata.equals("decipher"))
+                            selectedDatabase = DiseaseModel.database.DECIPHER;
+                        else {
+                            LOGGER.warn("did not recognize database " + userdata);
+                        }
+                    }
+                });
+        // now the HPO vs disease
+        ToggleGroup group2 = new ToggleGroup();
+        hpoTermRadioButton.setSelected(true);
+        hpoTermRadioButton.setToggleGroup(group2);
+        diseaseRadioButton.setToggleGroup(group2);
+        newAnnotationRadioButton.setToggleGroup(group2);
+        group2.selectedToggleProperty().addListener((ov, oldval, newval) -> {
+            String userdata = (String) newval.getUserData();
+            if (userdata.equals("hpo")) {
+                currentMode = MainController.mode.BROWSE_HPO;
+                if (labelsAndHpoIds != null) {
+                    WidthAwareTextFields.bindWidthAwareAutoCompletion(searchTextField, labelsAndHpoIds.keySet());
+                } else {
+                    LOGGER.error("Attempt to init autocomplete with null list of HPO terms");
+                }
+            } else if (userdata.equals("disease")) {
+                currentMode = BROWSE_DISEASE;
+                if (this.model.getDiseases() != null) {
+                    WidthAwareTextFields.bindWidthAwareAutoCompletion(searchTextField, model.getDiseases().keySet());
+                } else {
+                    LOGGER.warn("Attempt to init autocomplete with null list of diseases");
+                }
+            } else if (userdata.equals("newannotation")) {
+                currentMode = NEW_ANNOTATION;
+                if (labelsAndHpoIds != null) {
+                    WidthAwareTextFields.bindWidthAwareAutoCompletion(searchTextField, labelsAndHpoIds.keySet());
+                } else {
+                    LOGGER.error("Attempt to init autocomplete with null list of HPO terms");
+                }
+            }
+        });
+    }
+
+    private void switchToMode(MainController.mode Mode) {
+        if (Mode.equals(MainController.mode.BROWSE_HPO)) {
+            hpoTermRadioButton.setSelected(true);
+            currentMode = MainController.mode.BROWSE_HPO;
+        } else if (Mode.equals(BROWSE_DISEASE)) {
+            diseaseRadioButton.setSelected(true);
+            currentMode = MainController.mode.BROWSE_DISEASE;
+        } else if (Mode.equals(NEW_ANNOTATION)) {
+            currentMode = MainController.mode.NEW_ANNOTATION;
+        }
+    }
+
+    /**
+     * For the GitHub new issues, we want to allow the user to choose a pre-existing label for the issue.
+     * For this, we first go to GitHub and retrieve the labelsAndHpoIds with
+     * {@link org.monarchinitiative.hpoworkbench.github.GitHubLabelRetriever}. We only do this
+     * once per session though.
+     */
+    private void initializeGitHubLabelsIfNecessary() {
+        if (model.hasLabels()) {
+            return; // we only need to retrieve the labelsAndHpoIds from the server once per session!
+        }
+        GitHubLabelRetriever retriever = new GitHubLabelRetriever();
+        List<String> labels = retriever.getLabels();
+        if (labels == null) {
+            labels = new ArrayList<>();
+        }
+        if (labels.size() == 0) {
+            labels.add("new term request");
+        }
+        model.setGithublabels(labels);
+    }
+
+    private void postGitHubIssue(String message, String title, String uname, String pword) {
+        GitHubPoster poster = new GitHubPoster(uname, pword, title, message);
+        this.githubUsername = uname;
+        this.githubPassword = pword;
+        try {
+            poster.postIssue();
+        } catch (HPOWorkbenchException he) {
+            PopUps.showException("GitHub error", "Bad Request (400): Could not post issue", he);
+        } catch (Exception ex) {
+            PopUps.showException("GitHub error", "GitHub error: Could not post issue", ex);
+            return;
+        }
+        String response = poster.getHttpResponse();
+        PopUps.showInfoMessage(
+                String.format("Created issue for %s\nServer response: %s", selectedTerm.getName(), response), "Created new issue");
+    }
+
+    private void postGitHubIssue(String message, String title, String uname, String pword, List<String> labels) {
+        GitHubPoster poster = new GitHubPoster(uname, pword, title, message);
+        this.githubUsername = uname;
+        this.githubPassword = pword;
+        if (labels != null && !labels.isEmpty()) {
+            poster.setLabel(labels);
+        }
+        try {
+            poster.postIssue();
+        } catch (HPOWorkbenchException he) {
+            PopUps.showException("GitHub error", "Bad Request (400): Could not post issue", he);
+        } catch (Exception ex) {
+            PopUps.showException("GitHub error", "GitHub error: Could not post issue", ex);
+            return;
+        }
+        String response = poster.getHttpResponse();
+        PopUps.showInfoMessage(
+                String.format("Created issue for %s\nServer response: %s", selectedTerm.getName(), response), "Created new issue");
+    }
+
+
+    /**
+     * Get currently selected Term. Used in tests.
+     *
+     * @return {@link HpoTermTreeItem} that is currently selected
+     */
+    private HpoTermTreeItem getSelectedTerm() {
+        return (ontologyTreeView.getSelectionModel().getSelectedItem() == null) ? null
+                : (HpoTermTreeItem) ontologyTreeView.getSelectionModel().getSelectedItem();
+    }
+
+    /**
+     * Get the children of "term"
+     *
+     * @param term HPO Term of interest
+     *
+     * @return children of term (not including term itself).
+     */
+    private Set<HpoTerm> getTermChildren(HpoTerm term) {
+        HpoOntology ontology = optionalResources.getHpoOntology();
+        if (ontology == null) {
+            PopUps.showInfoMessage("Error: Could not initialize HPO Ontology", "ERROR");
+            return new HashSet<>(); // return empty set
+        }
+        TermId parentTermId = term.getId();
+        Set<TermId> childrenIds = getChildTerms(ontology, parentTermId, false);
+        Set<HpoTerm> kids = new HashSet<>();
+        childrenIds.forEach(tid -> {
+            HpoTerm ht = ontology.getTermMap().get(tid);
+            kids.add(ht);
+        });
+        return kids;
+    }
+
+    /**
+     * Get the parents of "term"
+     *
+     * @param term HPO Term of interest
+     *
+     * @return parents of term (not including term itself).
+     */
+    private Set<HpoTerm> getTermParents(HpoTerm term) {
+        HpoOntology ontology = optionalResources.getHpoOntology();
+        if (ontology == null) {
+            PopUps.showInfoMessage("Error: Could not initialize HPO Ontology", "ERROR");
+            return new HashSet<>(); // return empty set
+        }
+        Set<TermId> parentIds = getParentTerms(ontology, term.getId(), false);
+        Set<HpoTerm> eltern = new HashSet<>();
+        parentIds.forEach(tid -> {
+            HpoTerm ht = ontology.getTermMap().get(tid);
+            eltern.add(ht);
+        });
+        return eltern;
+    }
+
+    private boolean existsPathFromRoot(HpoTerm term) {
+        HpoOntology ontology = optionalResources.getHpoOntology();
+        if (ontology == null) {
+            PopUps.showInfoMessage("Error: Could not initialize HPO Ontology", "ERROR");
+            return false;
+        }
+        TermId rootId = ontology.getRootTermId();
+        TermId tid = term.getId();
+        return existsPath(ontology, tid, rootId);
+    }
+
+
+    /**
+     * Inner class that defines a bridge between hierarchy of {@link HpoTerm}s and {@link TreeItem}s of the
+     * {@link TreeView}.
+     */
+    class HpoTermTreeItem extends TreeItem<HpoTermWrapper> {
+
+        /** List used for caching of the children of this term */
+        private ObservableList<TreeItem<HpoTermWrapper>> childrenList;
+
+        /**
+         * Default & only constructor for the TreeItem.
+         *
+         * @param term {@link HpoTerm} that is represented by this TreeItem
+         */
+        HpoTermTreeItem(HpoTermWrapper term) {
+            super(term);
+        }
+
+        /**
+         * Check that the {@link HpoTerm} that is represented by this TreeItem is a leaf term as described below.
+         * <p>
+         * {@inheritDoc}
+         */
+        @Override
+        public boolean isLeaf() {
+            return getTermChildren(getValue().term).size() == 0;
+        }
+
+
+        /**
+         * Get list of children of the {@link HpoTerm} that is represented by this TreeItem.
+         * {@inheritDoc}
+         */
+        @Override
+        public ObservableList<TreeItem<HpoTermWrapper>> getChildren() {
+            if (childrenList == null) {
+                // logger.debug(String.format("Getting children for term %s", getValue().term.getName()));
+                childrenList = FXCollections.observableArrayList();
+                Set<HpoTerm> children = getTermChildren(getValue().term);
+                children.stream()
+                        .sorted(Comparator.comparing(HpoTerm::getName))
+                        .map(term -> new HpoTermTreeItem(new HpoTermWrapper(term)))
+                        .forEach(childrenList::add);
+                super.getChildren().setAll(childrenList);
+            }
+            return super.getChildren();
+        }
+    }
+}

--- a/hpowbgui/src/main/java/org/monarchinitiative/hpoworkbench/controller/MainController.java
+++ b/hpowbgui/src/main/java/org/monarchinitiative/hpoworkbench/controller/MainController.java
@@ -214,7 +214,7 @@ public class MainController {
         }
 
         ProgressIndicator pb = new ProgressIndicator();
-        javafx.scene.control.Label label = new javafx.scene.control.Label("downloading phenotype_annotation.tab...");
+        javafx.scene.control.Label label = new javafx.scene.control.Label("downloading phenotype.hpoa...");
         FlowPane root = new FlowPane();
         root.setPadding(new Insets(10));
         root.setHgap(10);

--- a/hpowbgui/src/main/java/org/monarchinitiative/hpoworkbench/controller/MainController.java
+++ b/hpowbgui/src/main/java/org/monarchinitiative/hpoworkbench/controller/MainController.java
@@ -173,11 +173,14 @@ public class MainController {
         window.setTitle("MONDO download");
         window.setScene(scene);
 
-        Task mondodownload = new Downloader(dirpath, properties.getProperty("mondo.obo.url"), PlatformUtil.MONDO_OBO_FILENAME);
-        pb.progressProperty().bind(mondodownload.progressProperty());
-
         logger.trace("mondo url = " +  properties.getProperty("mondo.obo.url"));
         logger.trace("mondo FN = " +  PlatformUtil.MONDO_OBO_FILENAME);
+        String MONDO_URL_HACK="https://osf.io/e87hn/download";
+
+        Task mondodownload = new Downloader(dirpath, MONDO_URL_HACK, PlatformUtil.MONDO_OBO_FILENAME);
+        pb.progressProperty().bind(mondodownload.progressProperty());
+
+
         window.show();
         mondodownload.setOnSucceeded(event -> {
             window.close();

--- a/hpowbgui/src/main/java/org/monarchinitiative/hpoworkbench/controller/MainController.java
+++ b/hpowbgui/src/main/java/org/monarchinitiative/hpoworkbench/controller/MainController.java
@@ -210,7 +210,7 @@ public class MainController {
         String dirpath = hpoWorkbenchDir.getAbsolutePath();
         File f = new File(dirpath);
         if (!(f.exists() && f.isDirectory())) {
-            logger.trace("Cannot download phenotype_annotation.tab, because directory not existing at " + f.getAbsolutePath());
+            logger.trace("Cannot download phenotype.hpoa, because directory not existing at " + f.getAbsolutePath());
             return;
         }
 

--- a/hpowbgui/src/main/java/org/monarchinitiative/hpoworkbench/controller/MainController.java
+++ b/hpowbgui/src/main/java/org/monarchinitiative/hpoworkbench/controller/MainController.java
@@ -1,64 +1,34 @@
 package org.monarchinitiative.hpoworkbench.controller;
 
 
+import com.google.inject.Inject;
 import javafx.application.Platform;
-import javafx.beans.binding.BooleanBinding;
-import javafx.beans.value.ChangeListener;
-import javafx.beans.value.ObservableValue;
-import javafx.collections.FXCollections;
-import javafx.collections.ObservableList;
 import javafx.concurrent.Task;
-import javafx.concurrent.Worker;
 import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
 import javafx.geometry.Insets;
 import javafx.scene.Scene;
-import javafx.scene.control.*;
+import javafx.scene.control.Alert;
+import javafx.scene.control.ProgressIndicator;
 import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.StackPane;
-import javafx.scene.web.WebEngine;
-import javafx.scene.web.WebView;
 import javafx.stage.FileChooser;
 import javafx.stage.Stage;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.monarchinitiative.hpoworkbench.excel.HierarchicalExcelExporter;
-import org.monarchinitiative.hpoworkbench.excel.Hpo2ExcelExporter;
-import org.monarchinitiative.hpoworkbench.exception.HPOException;
-import org.monarchinitiative.hpoworkbench.exception.HPOWorkbenchException;
-import org.monarchinitiative.hpoworkbench.github.GitHubLabelRetriever;
-import org.monarchinitiative.hpoworkbench.github.GitHubPoster;
-import org.monarchinitiative.hpoworkbench.gui.*;
+import org.monarchinitiative.hpoworkbench.gui.HelpViewFactory;
+import org.monarchinitiative.hpoworkbench.gui.PlatformUtil;
+import org.monarchinitiative.hpoworkbench.gui.PopUps;
 import org.monarchinitiative.hpoworkbench.io.DirectIndirectHpoAnnotationParser;
 import org.monarchinitiative.hpoworkbench.io.Downloader;
 import org.monarchinitiative.hpoworkbench.io.HPOParser;
 import org.monarchinitiative.hpoworkbench.io.MondoParser;
-import org.monarchinitiative.hpoworkbench.model.DiseaseModel;
-import org.monarchinitiative.hpoworkbench.model.Model;
 import org.monarchinitiative.hpoworkbench.resources.OptionalResources;
 import org.monarchinitiative.phenol.base.PhenolException;
-import org.monarchinitiative.phenol.formats.hpo.HpoOntology;
-import org.monarchinitiative.phenol.formats.hpo.HpoTerm;
-import org.monarchinitiative.phenol.ontology.data.ImmutableTermId;
-import org.monarchinitiative.phenol.ontology.data.TermId;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-import org.w3c.dom.NodeList;
-import org.w3c.dom.events.EventListener;
-import org.w3c.dom.events.EventTarget;
 
-import javax.inject.Inject;
 import javax.inject.Named;
 import java.io.File;
-import java.util.*;
-import java.util.function.Consumer;
-
-import static org.monarchinitiative.hpoworkbench.controller.MainController.mode.BROWSE_DISEASE;
-import static org.monarchinitiative.hpoworkbench.controller.MainController.mode.BROWSE_HPO;
-import static org.monarchinitiative.hpoworkbench.controller.MainController.mode.NEW_ANNOTATION;
-import static org.monarchinitiative.phenol.ontology.algo.OntologyAlgorithm.existsPath;
-import static org.monarchinitiative.phenol.ontology.algo.OntologyAlgorithm.getChildTerms;
-import static org.monarchinitiative.phenol.ontology.algo.OntologyAlgorithm.getParentTerms;
+import java.util.Properties;
 
 
 /**
@@ -69,16 +39,10 @@ import static org.monarchinitiative.phenol.ontology.algo.OntologyAlgorithm.getPa
 public class MainController {
     private static final Logger logger = LogManager.getLogger();
 
-    private static final String EVENT_TYPE_CLICK = "click";
-
-    private static final String EVENT_TYPE_MOUSEOVER = "mouseover";
-
-    private static final String EVENT_TYPE_MOUSEOUT = "mouseclick";
-
     private final OptionalResources optionalResources;
 
     /**
-     * Unused, but still required
+     * Directory, where ontologies and HPO annotation files are being stored.
      */
     private final File hpoWorkbenchDir;
 
@@ -89,101 +53,19 @@ public class MainController {
     private final Properties properties;
 
     /** Reference to the primary stage of the App. */
-    private final Stage primarystage;
-
-    @com.google.inject.Inject
-    private MondoController mondoController;
-
-
-    @FXML
-    private TabPane tabPane;
-    @FXML private Tab hpoTab;
-    @FXML private Tab mondoTab;
-
-    @FXML
-    public Button exportHierarchicalSummaryButton;
-
-    @FXML
-    public Button exportToExcelButton;
-
-    @FXML
-    public Button suggestCorrectionToTermButton;
-
-    @FXML
-    public Button suggestNewChildTermButton;
-
-    @FXML
-    public Button suggestNewAnnotationButton;
-
-    @FXML
-    public Button reportMistakenAnnotationButton;
+    private final Stage primaryStage;
 
     /** Place at the bottom of the window controlled by {@link StatusController} for showing messages to user */
     @FXML
     public StackPane statusStackPane;
 
-    private Model model;
-
-
-    /** Users can create a github issue. Username and password will be stored for the current session only. */
-    private String githubUsername = null;
-
-    private String githubPassword;
-
-    /** This determines which disease as shown (OMIM, Orphanet, DECIPHER, or all). Default: ALL. */
-    private DiseaseModel.database selectedDatabase = DiseaseModel.database.ALL;
-
-    /** Current behavior of HPO Workbench. See {@link mode}. */
-    private mode currentMode = mode.BROWSE_HPO;
-
-    /** Approved {@link HpoTerm} is submitted here. */
-    private Consumer<HpoTerm> addHook;
-
-    /** The term that is currently selected in the Browser window. */
-    private HpoTerm selectedTerm = null;
-
-    /** Current disease shown in the browser. Any suggested changes will refer to this disease. */
-    private DiseaseModel selectedDisease = null;
-
-    /** Key: a term name such as "Myocardial infarction"; value: the corresponding HPO id as a {@link TermId}. */
-    private Map<String, TermId> labelsAndHpoIds = new HashMap<>();
-
-    /** Tree hierarchy of the ontology is presented here. */
-    @FXML
-    private TreeView<HpoTermWrapper> ontologyTreeView;
-
-    /** WebView for displaying details of the Term that is selected in the {@link #ontologyTreeView}. */
-    @FXML
-    private WebView infoWebView;
-
-    /** WebEngine backing up the {@link #infoWebView}. */
-    private WebEngine infoWebEngine;
-
-    /** Text field with autocompletion for jumping to a particular HPO term in the tree view. */
-    @FXML
-    private TextField searchTextField;
-
-    @FXML
-    private Button goButton;
-
-    @FXML
-    private RadioButton allDatabaseButton, orphanetButton, omimButton, decipherButton;
-
-    @FXML
-    private RadioButton hpoTermRadioButton;
-
-    @FXML
-    private RadioButton diseaseRadioButton;
-
-    @FXML
-    private RadioButton newAnnotationRadioButton;
 
     @Inject
     public MainController(OptionalResources optionalResources, Properties properties,
-                          @Named("mainWindow") Stage primarystage, @Named("hpoWorkbenchDir") File hpoWorkbenchDir) {
+                          @Named("mainWindow") Stage primaryStage, @Named("hpoWorkbenchDir") File hpoWorkbenchDir) {
         this.optionalResources = optionalResources;
         this.properties = properties;
-        this.primarystage = primarystage;
+        this.primaryStage = primaryStage;
         this.hpoWorkbenchDir = hpoWorkbenchDir;
     }
 
@@ -209,7 +91,7 @@ public class MainController {
         chooser.setTitle("Import local hp.obo file");
         FileChooser.ExtensionFilter extFilter = new FileChooser.ExtensionFilter("HPO OBO file (*.obo)", "*.obo");
         chooser.getExtensionFilters().add(extFilter);
-        File f = chooser.showOpenDialog(primarystage);
+        File f = chooser.showOpenDialog(primaryStage);
         if (f == null) {
             logger.error("Unable to obtain path to local HPO OBO file");
             PopUps.showInfoMessage("Unable to obtain path to local HPO OBO file", "Error");
@@ -220,7 +102,6 @@ public class MainController {
         HPOParser parser = new HPOParser(hpoOboPath);
         optionalResources.setHpoOntology(parser.getHPO());
         properties.setProperty("hpo.obo.path", hpoOboPath);
-
     }
 
     @FXML
@@ -231,7 +112,7 @@ public class MainController {
 
     @FXML
     private void downloadHPO(ActionEvent e) {
-        String dirpath = PlatformUtil.getHpoWorkbenchDir().getAbsolutePath();
+        String dirpath = hpoWorkbenchDir.getAbsolutePath();
         File f = new File(dirpath);
         if (!(f.exists() && f.isDirectory())) {
             logger.trace("Cannot download hp.obo, because directory not existing at " + f.getAbsolutePath());
@@ -246,15 +127,16 @@ public class MainController {
         root.getChildren().addAll(label, pb);
         Scene scene = new Scene(root, 400, 100);
         Stage window = new Stage();
-        window.initOwner(primarystage);
+        window.initOwner(primaryStage);
         window.setTitle("HPO download");
         window.setScene(scene);
 
-        Task hpodownload = new Downloader(dirpath, properties.getProperty("hpo.obo.url"), PlatformUtil.HPO_OBO_FILENAME, pb);
+        Task hpodownload = new Downloader(dirpath, properties.getProperty("hpo.obo.url"), PlatformUtil.HPO_OBO_FILENAME);
+        pb.progressProperty().bind(hpodownload.progressProperty());
         window.show();
         hpodownload.setOnSucceeded(event -> {
             window.close();
-            logger.trace(String.format("Successfully downloaded hpo to %s", dirpath));
+            logger.info(String.format("Successfully downloaded hpo to %s", dirpath));
             String hpoOboPath = dirpath + File.separator + PlatformUtil.HPO_OBO_FILENAME;
             optionalResources.setHpoOntology(new HPOParser(hpoOboPath).getHPO());
             properties.setProperty("hpo.obo.path", hpoOboPath);
@@ -263,7 +145,7 @@ public class MainController {
             window.close();
             logger.error("Unable to download HPO obo file");
             optionalResources.setHpoOntology(null);
-            properties.setProperty("hpo.obo.path", null);
+            properties.remove("hpo.obo.path");
         });
         Thread thread = new Thread(hpodownload);
         thread.start();
@@ -272,7 +154,7 @@ public class MainController {
 
     @FXML
     private void downloadMondo(ActionEvent e) {
-        String dirpath = PlatformUtil.getHpoWorkbenchDir().getAbsolutePath();
+        String dirpath = hpoWorkbenchDir.getAbsolutePath();
         File f = new File(dirpath);
         if (!(f.exists() && f.isDirectory())) {
             logger.trace("Cannot download mondo.obo, because directory does not exist at " + f.getAbsolutePath());
@@ -287,13 +169,12 @@ public class MainController {
         root.getChildren().addAll(label, pb);
         Scene scene = new Scene(root, 400, 100);
         Stage window = new Stage();
-        window.initOwner(primarystage);
+        window.initOwner(primaryStage);
         window.setTitle("MONDO download");
         window.setScene(scene);
-        if (properties.getProperty("mondo.obo.url")==null) { //TODO WHY ISNT THIS BEING SET?
-            properties.setProperty("mondo.obo.url","https://osf.io/e87hn/download");
-        }
-        Task mondodownload = new Downloader(dirpath, properties.getProperty("mondo.obo.url"), PlatformUtil.MONDO_OBO_FILENAME, pb);
+
+        Task mondodownload = new Downloader(dirpath, properties.getProperty("mondo.obo.url"), PlatformUtil.MONDO_OBO_FILENAME);
+        pb.progressProperty().bind(mondodownload.progressProperty());
 
         logger.trace("mondo url = " +  properties.getProperty("mondo.obo.url"));
         logger.trace("mondo FN = " +  PlatformUtil.MONDO_OBO_FILENAME);
@@ -313,7 +194,7 @@ public class MainController {
             window.close();
             logger.error("Unable to download MONDO obo file");
             optionalResources.setMondoOntology(null);
-            properties.setProperty("mondo.obo.path", null);
+            properties.remove("mondo.obo.path");
         });
         Thread thread = new Thread(mondodownload);
         thread.start();
@@ -322,7 +203,7 @@ public class MainController {
 
     @FXML
     private void downloadHPOAnnotations(ActionEvent e) {
-        String dirpath = PlatformUtil.getHpoWorkbenchDir().getAbsolutePath();
+        String dirpath = hpoWorkbenchDir.getAbsolutePath();
         File f = new File(dirpath);
         if (!(f.exists() && f.isDirectory())) {
             logger.trace("Cannot download phenotype_annotation.tab, because directory not existing at " + f.getAbsolutePath());
@@ -341,7 +222,8 @@ public class MainController {
         window.setScene(scene);
 
         Task hpodownload = new Downloader(dirpath, properties.getProperty("hpo.phenotype.annotations.url"),
-                PlatformUtil.HPO_ANNOTATIONS_FILENAME, pb);
+                PlatformUtil.HPO_ANNOTATIONS_FILENAME);
+        pb.progressProperty().bind(hpodownload.progressProperty());
         window.show();
         hpodownload.setOnSucceeded(event -> {
             window.close();
@@ -360,665 +242,16 @@ public class MainController {
             logger.error("Unable to download phenotype_annotation.tab file");
             optionalResources.setIndirectAnnotMap(null);
             optionalResources.setDirectAnnotMap(null);
-            properties.setProperty("hpo.annotations.path", null);
+            properties.remove("hpo.annotations.path");
         });
         Thread thread = new Thread(hpodownload);
         thread.start();
         e.consume();
     }
 
-    /**
-     * Expand & scroll to the term selected in the search text field.
-     */
-    @FXML
-    private void goButtonAction() {
-        if (currentMode.equals(BROWSE_DISEASE)) {
-            DiseaseModel dmod = model.getDiseases().get(searchTextField.getText());
-            if (dmod == null) return;
-            updateDescriptionToDiseaseModel(dmod);
-            selectedDisease = dmod;
-            searchTextField.clear();
-        } else if (currentMode.equals(mode.BROWSE_HPO)) {
-            TermId id = labelsAndHpoIds.get(searchTextField.getText());
-            if (id == null) return; // button was clicked while field was empty, no need to do anything
-            expandUntilTerm(optionalResources.getHpoOntology().getTermMap().get(id));
-            searchTextField.clear();
-        } else if (currentMode == mode.NEW_ANNOTATION) {
-            TermId id = labelsAndHpoIds.get(searchTextField.getText());
-            if (id == null) return; // button was clicked while field was empty, no need to do anything
-            expandUntilTerm(optionalResources.getHpoOntology().getTermMap().get(id));
-            searchTextField.clear();
-        }
-    }
-
     @FXML
     public void initialize() {
-        //logger.trace("initialize");
-//        // This action will be run after user approves a PhenotypeTerm in the ontologyTreePane
-//        Consumer<HpoTerm> addHook = (ph -> logger.trace(String.format("Hook for %s", ph.getName())));
-
-        initRadioButtons();
-
-        // this binding evaluates to true, if ontology or annotations files are missing (null)
-        BooleanBinding someResourceMissing = optionalResources.someResourceMissing();
-
-        hpoTermRadioButton.disableProperty().bind(someResourceMissing);
-        diseaseRadioButton.disableProperty().bind(someResourceMissing);
-        newAnnotationRadioButton.disableProperty().bind(someResourceMissing);
-
-        searchTextField.disableProperty().bind(someResourceMissing);
-        goButton.disableProperty().bind(someResourceMissing);
-        ontologyTreeView.disableProperty().bind(someResourceMissing);
-
-        exportHierarchicalSummaryButton.disableProperty().bind(someResourceMissing);
-        exportToExcelButton.disableProperty().bind(someResourceMissing);
-        suggestCorrectionToTermButton.disableProperty().bind(someResourceMissing);
-        suggestNewChildTermButton.disableProperty().bind(someResourceMissing);
-        suggestNewAnnotationButton.disableProperty().bind(someResourceMissing);
-        reportMistakenAnnotationButton.disableProperty().bind(someResourceMissing);
-
-
-        someResourceMissing.addListener(((observable, oldValue, newValue) -> {
-            if (!newValue) { // nothing is missing anymore
-                activate();
-            } else { // invalidate model and anything in the background. Controls should be disabled automatically
-                deactivate();
-            }
-        }));
-
-
-        if (!someResourceMissing.get()) {
-            activate();
-        }
-
-        tabPane.getSelectionModel().selectedItemProperty().addListener(new ChangeListener<Tab>() {
-            @Override
-            public void changed(ObservableValue<? extends Tab> observable, Tab oldValue, Tab newValue) {
-
-                if(newValue.equals(hpoTab)) {
-                    // ?? What
-                } else if (newValue.equals(mondoTab)) {
-                    //
-                    mondoController.initialize();
-                }
-
-
-            }
-        });
-    }
-
-    private void activate() {
-        initTree(optionalResources.getHpoOntology(), k -> System.out.println("Consumed " + k));
-        this.model = new Model(optionalResources.getHpoOntology(), optionalResources.getIndirectAnnotMap(),
-                optionalResources.getDirectAnnotMap());
-    }
-
-    private void deactivate() {
-        initTree(null, k -> System.out.println("Consumed " + k));
-        this.model = new Model(null, null, null);
-    }
-
-    @Deprecated
-    private void initHpoData() {
-        if (model.getOntology() == null) {
-            logger.error("Need to initialize ontology before we can start the application.");
-            return;
-        }
-        initTree(model.getOntology(), addHook);
-        logger.trace("Finished initilizing Human Phenotype Ontology");
-    }
-
-    private void initRadioButtons() {
-        ToggleGroup group = new ToggleGroup();
-        allDatabaseButton.setSelected(true);
-        allDatabaseButton.setToggleGroup(group);
-        omimButton.setSelected(false);
-        omimButton.setToggleGroup(group);
-        orphanetButton.setSelected(false);
-        orphanetButton.setToggleGroup(group);
-        decipherButton.setSelected(false);
-        decipherButton.setToggleGroup(group);
-        group.selectedToggleProperty().addListener(
-                (ObservableValue<? extends Toggle> ov, Toggle old_toggle, Toggle new_toggle) -> {
-                    if (group.getSelectedToggle() != null) {
-                        String userdata = (String) group.getSelectedToggle().getUserData();
-                        if (userdata == null) {
-                            logger.warn("Could not retrieve user data for database radio buttons");
-                        }
-                        if (userdata.equals("orphanet"))
-                            selectedDatabase = DiseaseModel.database.ORPHANET;
-                        else if (userdata.equals("omim"))
-                            selectedDatabase = DiseaseModel.database.OMIM;
-                        else if (userdata.equals("all"))
-                            selectedDatabase = DiseaseModel.database.ALL;
-                        else if (userdata.equals("decipher"))
-                            selectedDatabase = DiseaseModel.database.DECIPHER;
-                        else {
-                            logger.warn("did not recognize database " + userdata);
-                        }
-                    }
-                });
-        // now the HPO vs disease
-        ToggleGroup group2=new ToggleGroup();
-        hpoTermRadioButton.setSelected(true);
-        hpoTermRadioButton.setToggleGroup(group2);
-        diseaseRadioButton.setToggleGroup(group2);
-        newAnnotationRadioButton.setToggleGroup(group2);
-        group2.selectedToggleProperty().addListener((ov,oldval,newval) ->{
-            String userdata=(String)newval.getUserData();
-            if (userdata.equals("hpo")) {
-                currentMode=mode.BROWSE_HPO;
-                if (labelsAndHpoIds !=null) {
-                    WidthAwareTextFields.bindWidthAwareAutoCompletion(searchTextField, labelsAndHpoIds.keySet());
-                } else {
-                    logger.error("Attempt to init autocomplete with null list of HPO terms");
-                }
-            } else if (userdata.equals("disease")){
-                currentMode= BROWSE_DISEASE;
-                if (this.model.getDiseases()!=null) {
-                    WidthAwareTextFields.bindWidthAwareAutoCompletion(searchTextField,model.getDiseases().keySet());
-                } else {
-                    logger.warn("Attempt to init autocomplete with null list of diseases");
-                }
-            } else if (userdata.equals("newannotation")) {
-                currentMode=NEW_ANNOTATION;
-                if (labelsAndHpoIds !=null) {
-                    WidthAwareTextFields.bindWidthAwareAutoCompletion(searchTextField, labelsAndHpoIds.keySet());
-                } else {
-                    logger.error("Attempt to init autocomplete with null list of HPO terms");
-                }
-            }
-        });
-    }
-
-
-    private void switchToMode(mode Mode) {
-        if(Mode.equals( mode.BROWSE_HPO) ) {
-            hpoTermRadioButton.setSelected(true);
-            currentMode = mode.BROWSE_HPO;
-        } else if (Mode.equals(BROWSE_DISEASE)) {
-            diseaseRadioButton.setSelected(true);
-            currentMode = mode.BROWSE_DISEASE;
-        } else if (Mode.equals(NEW_ANNOTATION)) {
-            currentMode = mode.NEW_ANNOTATION;
-        }
-    }
-
-
-    /**
-     * Initialize the ontology browser-tree in the left column of the app.
-     *
-     * @param ontology Reference to the HPO
-     * @param addHook  function hook (currently unused)
-     */
-    private void initTree(HpoOntology ontology, Consumer<HpoTerm> addHook) {
-        // populate the TreeView with top-level elements from ontology hierarchy
-        if (ontology == null) {
-            ontologyTreeView.setRoot(null);
-            return;
-        }
-        TermId rootId = ontology.getRootTermId();
-        HpoTerm rootTerm = ontology.getTermMap().get(rootId);
-        TreeItem<HpoTermWrapper> root = new HpoTermTreeItem(new HpoTermWrapper(rootTerm));
-        root.setExpanded(true);
-//        if (ontologyTreeView==null) {
-//            logger.fatal("Tree view is not initialized");
-//            return;
-//        }
-        ontologyTreeView.setShowRoot(false);
-        ontologyTreeView.setRoot(root);
-        ontologyTreeView.getSelectionModel().selectedItemProperty()
-                .addListener((observable, oldValue, newValue) -> {
-                    if (newValue == null) {
-                        logger.error("New value is null");
-                        return;
-                    }
-                    HpoTermWrapper w = newValue.getValue();
-                    TreeItem item = new HpoTermTreeItem(w);
-                    updateDescription(item);
-                });
-        // create Map for lookup of the terms in the ontology based on their Name
-        ontology.getTermMap().values().forEach(term -> {
-            labelsAndHpoIds.put(term.getName(), term.getId());
-            labelsAndHpoIds.put(term.getId().getIdWithPrefix(),term.getId());
-        });
-        WidthAwareTextFields.bindWidthAwareAutoCompletion(searchTextField, labelsAndHpoIds.keySet());
-
-        // show intro message in the infoWebView
-        Platform.runLater(() -> {
-            infoWebEngine = infoWebView.getEngine();
-            infoWebEngine.loadContent("<!DOCTYPE html><html lang=\"en\"><head><meta charset=\"UTF-8\"><title>HPO tree browser</title></head>" +
-                    "<body><p>Click on HPO term in the tree browser to display additional information</p></body></html>");
-        });
-    }
-
-    /**
-     * Find the path from the root term to given {@link HpoTerm}, expand the tree and set the selection model of the
-     * TreeView to the term position.
-     *
-     * @param term {@link HpoTerm} to be displayed
-     */
-    private void expandUntilTerm(HpoTerm term) {
-        // logger.trace("expand until term " + term.toString());
-        switchToMode(BROWSE_HPO);
-        if (existsPathFromRoot(term)) {
-            // find root -> term path through the tree
-            Stack<HpoTerm> termStack = new Stack<>();
-            termStack.add(term);
-            Set<HpoTerm> parents = getTermParents(term);
-            while (parents.size() != 0) {
-                HpoTerm parent = parents.iterator().next();
-                termStack.add(parent);
-                parents = getTermParents(parent);
-            }
-
-            // expand tree nodes in top -> down direction
-            List<TreeItem<HpoTermWrapper>> children = ontologyTreeView.getRoot().getChildren();
-            termStack.pop(); // get rid of 'All' node which is hidden
-            TreeItem<HpoTermWrapper> target = ontologyTreeView.getRoot();
-            while (!termStack.empty()) {
-                HpoTerm current = termStack.pop();
-                for (TreeItem<HpoTermWrapper> child : children) {
-                    if (child.getValue().term.equals(current)) {
-                        child.setExpanded(true);
-                        target = child;
-                        children = child.getChildren();
-                        break;
-                    }
-                }
-            }
-            ontologyTreeView.getSelectionModel().select(target);
-            ontologyTreeView.scrollTo(ontologyTreeView.getSelectionModel().getSelectedIndex());
-        } else {
-            TermId rootId = optionalResources.getHpoOntology().getRootTermId();
-            HpoTerm rootTerm = optionalResources.getHpoOntology().getTermMap().get(rootId);
-            logger.warn(String.format("Unable to find the path from %s to %s", rootTerm.toString(), term.getName()));
-        }
-        selectedTerm = term;
-    }
-
-    /**
-     * Get currently selected Term. Used in tests.
-     *
-     * @return {@link HpoTermTreeItem} that is currently selected
-     */
-    private HpoTermTreeItem getSelectedTerm() {
-        return (ontologyTreeView.getSelectionModel().getSelectedItem() == null) ? null
-                : (HpoTermTreeItem) ontologyTreeView.getSelectionModel().getSelectedItem();
-    }
-
-    /**
-     * Update content of the {@link #infoWebView} with currently selected {@link HpoTerm}.
-     *
-     * @param treeItem currently selected {@link TreeItem} containing {@link HpoTerm}
-     */
-    private void updateDescription(TreeItem<HpoTermWrapper> treeItem) {
-        logger.trace("TOP OF UPDATE DESCRIPTION");
-        if (currentMode.equals(mode.NEW_ANNOTATION)) {
-            return;
-        }
-        if (treeItem == null)
-            return;
-
-        HpoTerm term = treeItem.getValue().term;
-        String termID = term.getId().getIdWithPrefix();
-        List<DiseaseModel> annotatedDiseases = model.getDiseaseAnnotations(termID, selectedDatabase);
-        if (annotatedDiseases == null) {
-            logger.error("could not retrieve diseases for " + termID);
-        }
-        int n_descendents = 42;//getDescendents(model.getOntology(),term.getId()).size();
-        //todo--add number of descendents to HTML
-        String content = HpoHtmlPageGenerator.getHTML(term, annotatedDiseases);
-        //System.out.print(content);
-        // infoWebEngine=this.infoWebView.getEngine();
-        infoWebEngine.loadContent(content);
-        infoWebEngine.getLoadWorker().stateProperty().addListener(new ChangeListener<Worker.State>() {
-            @Override
-            public void changed(ObservableValue ov, Worker.State oldState, Worker.State newState) {
-                logger.trace("TOP OF CHANGED  UPDATE DESCRIPTION");
-                if (newState == Worker.State.SUCCEEDED) {
-                    org.w3c.dom.events.EventListener listener = new EventListener() {
-                        @Override
-                        public void handleEvent(org.w3c.dom.events.Event ev) {
-                            String domEventType = ev.getType();
-                           // System.err.println("EventType FROM updateHPO: " + domEventType);
-                            if (domEventType.equals(EVENT_TYPE_CLICK)) {
-                                String href = ((Element) ev.getTarget()).getAttribute("href");
-                                // System.out.println("HREF "+href);
-                                if (href.equals("http://www.human-phenotype-ontology.org")) {
-                                    return; // the external link is taken care of by the Webengine
-                                    // therefore, we do not need to do anything special here
-                                }
-                                // The following line is necessary because sometimes multiple events are triggered
-                                // and we get a "stray" HPO-related link that does not belong here.
-                                if (href.startsWith("HP:")) return;
-                                DiseaseModel dmod = model.getDiseases().get(href);
-                                if (dmod == null) {
-                                    logger.error("Link to disease model for " + href + " was null");
-                                    return;
-                                }
-                                updateDescriptionToDiseaseModel(dmod);
-                                selectedDisease = dmod;
-                                searchTextField.clear();
-                                currentMode = BROWSE_DISEASE;
-                                diseaseRadioButton.setSelected(true);
-                            }
-                        }
-                    };
-
-                    Document doc = infoWebView.getEngine().getDocument();
-                    NodeList nodeList = doc.getElementsByTagName("a");
-                    for (int i = 0; i < nodeList.getLength(); i++) {
-                        ((EventTarget) nodeList.item(i)).addEventListener(EVENT_TYPE_CLICK, listener, false);
-                        //((EventTarget) nodeList.item(i)).addEventListener(EVENT_TYPE_MOUSEOVER, listener, false);
-                        //((EventTarget) nodeList.item(i)).addEventListener(EVENT_TYPE_MOUSEOVER, listener, false);
-                    }
-                }
-            }
-        });
-
-    }
-
-    /**
-     * Update content of the {@link #infoWebView} with currently selected {@link HpoTerm}.
-     * The function is called when the user is on an HPO Term page and selects a link to
-     * a disease.
-     *
-     * @param dmodel currently selected {@link TreeItem} containing {@link HpoTerm}
-     */
-    private void updateDescriptionToDiseaseModel(DiseaseModel dmodel) {
-        logger.trace("TOP OF updateDescriptionToDiseaseModel");
-        String dbName = dmodel.getDiseaseDbAndId();
-        String diseaseName = dmodel.getDiseaseName();
-        List<HpoTerm> annotatingTerms = model.getAnnotationTermsForDisease(dmodel);
-        String content = HpoHtmlPageGenerator.getDiseaseHTML(dbName, diseaseName, annotatingTerms, optionalResources
-                .getHpoOntology());
-        infoWebEngine.loadContent(content);
-        infoWebEngine.getLoadWorker().stateProperty().addListener(new ChangeListener<Worker.State>() {
-            @Override
-            public void changed(ObservableValue ov, Worker.State oldState, Worker.State newState) {
-                logger.trace("TOP OF CHANGED updateDescriptionToDiseaseModel");
-                if (newState == Worker.State.SUCCEEDED) {
-                    org.w3c.dom.events.EventListener listener = new EventListener() {
-                        @Override
-                        public void handleEvent(org.w3c.dom.events.Event ev) {
-                            String domEventType = ev.getType();
-                            //System.err.println("EventType from updateToDisease: " + domEventType);
-                            if (domEventType.equals(EVENT_TYPE_CLICK)) {
-                                String href = ((Element) ev.getTarget()).getAttribute("href");
-                                if (href.equals("http://www.human-phenotype-ontology.org")) {
-                                    return; // the external link is taken care of by the Webengine
-                                    // therefore, we do not need to do anything special here
-                                }
-                                // The following line is needed because sometimes we get multiple click events
-                                // if the user clicks once and some appear to be for the "wrong" link type.
-                                if (!href.startsWith("HP:")) { return; }
-                                TermId tid = ImmutableTermId.constructWithPrefix(href);
-                                HpoTerm term = optionalResources.getHpoOntology().getTermMap().get(tid);
-                                if (term == null) {
-                                    logger.error(String.format("Could not construct term  from termid \"%s\"", tid.getIdWithPrefix()));
-                                    return;
-                                }
-                                // set the tree on the left to our new term
-                                expandUntilTerm(term);
-                                // update the Webview browser
-                                logger.trace("ABOUT TO UPDATE DESCRIPTION FOR " + term.getName());
-                                updateDescription(new HpoTermTreeItem(new HpoTermWrapper(term)));
-                                searchTextField.clear();
-                                currentMode = mode.BROWSE_HPO;
-                                hpoTermRadioButton.setSelected(true);
-                            }
-                        }
-                    };
-
-                    Document doc = infoWebView.getEngine().getDocument();
-                    NodeList nodeList = doc.getElementsByTagName("a");
-                    for (int i = 0; i < nodeList.getLength(); i++) {
-                        ((EventTarget) nodeList.item(i)).addEventListener(EVENT_TYPE_CLICK, listener, false);
-                        //((EventTarget) nodeList.item(i)).addEventListener(EVENT_TYPE_MOUSEOVER, listener, false);
-                        //((EventTarget) nodeList.item(i)).addEventListener(EVENT_TYPE_MOUSEOVER, listener, false);
-                    }
-                }
-            }
-        });
-    }
-
-    @FXML
-    private void exportToExcel(ActionEvent event) {
-        logger.trace("exporting to excel");
-        FileChooser chooser = new FileChooser();
-        chooser.setTitle("Export HPO as Excel-format file");
-        FileChooser.ExtensionFilter extFilter = new FileChooser.ExtensionFilter("Excel file (*.xlsx)", "*.xlsx");
-        chooser.getExtensionFilters().add(extFilter);
-        chooser.setInitialFileName("hpo.xlsx");
-        File f = chooser.showSaveDialog(null);
-        if (f != null) {
-            String path = f.getAbsolutePath();
-            logger.trace(String.format("Setting path to LOINC Core Table file to %s", path));
-            Hpo2ExcelExporter exporter = new Hpo2ExcelExporter(model.getOntology());
-            exporter.exportToExcelFile(path);
-        } else {
-            logger.error("Unable to obtain path to Excel export file");
-        }
-        event.consume();
-    }
-
-    @FXML
-    private void exportHierarchicalSummary(ActionEvent event) {
-        if (selectedTerm==null) {
-            selectedTerm = getSelectedTerm().getValue().term;
-        }
-        if (selectedTerm == null) { // should only happen if the user hasn't selected anything at all.
-            logger.error("Select a term before exporting hierarchical summary TODO show error window");
-            PopUps.showInfoMessage("Please select an HPO term in order to export a term with its subhierarchy",
-                    "Error: No HPO Term selected");
-            return; // to do throw exceptio
-        }
-        selectedTerm = getSelectedTerm().getValue().term;
-        FileChooser chooser = new FileChooser();
-        chooser.setTitle("Export HPO as Excel-format file");
-        FileChooser.ExtensionFilter extFilter = new FileChooser.ExtensionFilter("Excel file (*.xlsx)", "*.xlsx");
-        chooser.getExtensionFilters().add(extFilter);
-        chooser.setInitialFileName(String.format("%s.xlsx", selectedTerm.getName()));
-        File f = chooser.showSaveDialog(null);
-        if (f != null) {
-            String path = f.getAbsolutePath();
-            logger.trace(String.format("Setting path to hierarchical export file to %s", path));
-        } else {
-            logger.error("Unable to obtain path to Excel export file");
-            return;
-        }
-        logger.trace(String.format("Exporting hierarchical summary starting from term %s", selectedTerm.toString()));
-        HierarchicalExcelExporter exporter = new HierarchicalExcelExporter(model.getOntology(), selectedTerm);
-        try {
-            exporter.exportToExcel(f.getAbsolutePath());
-        } catch (HPOException e) {
-            PopUps.showException("Error", "could not export excel file", e);
-        }
-    }
-
-    /**
-     * For the GitHub new issues, we want to allow the user to choose a pre-existing label for the issue.
-     * For this, we first go to GitHub and retrieve the labelsAndHpoIds with
-     * {@link org.monarchinitiative.hpoworkbench.github.GitHubLabelRetriever}. We only do this
-     * once per session though.
-     */
-    private void initializeGitHubLabelsIfNecessary() {
-        if (model.hasLabels()) {
-            return; // we only need to retrieve the labelsAndHpoIds from the server once per session!
-        }
-        GitHubLabelRetriever retriever = new GitHubLabelRetriever();
-        List<String> labels = retriever.getLabels();
-        if (labels == null) {
-            labels = new ArrayList<>();
-        }
-        if (labels.size() == 0) {
-            labels.add("new term request");
-        }
-        model.setGithublabels(labels);
-    }
-
-    @FXML
-    private void suggestCorrectionToTerm(ActionEvent e) {
-        if (getSelectedTerm() == null) {
-            logger.error("Select a term before creating GitHub issue");
-            PopUps.showInfoMessage("Please select an HPO term before creating GitHub issue",
-                    "Error: No HPO Term selected");
-            return;
-        } else {
-            selectedTerm = getSelectedTerm().getValue().term;
-        }
-        selectedTerm = getSelectedTerm().getValue().term;
-        GitHubPopup popup = new GitHubPopup(selectedTerm);
-        initializeGitHubLabelsIfNecessary();
-        popup.setLabels(model.getGithublabels());
-        popup.setupGithubUsernamePassword(githubUsername, githubPassword);
-        popup.displayWindow(primarystage);
-        String githubissue = popup.retrieveGitHubIssue();
-        if (popup.wasCancelled()) {
-            return;
-        }
-        if (githubissue == null) {
-            logger.trace("got back null GitHub issue");
-            return;
-        }
-        String title = String.format("Correction to term %s", selectedTerm.getName());
-        postGitHubIssue(githubissue, title, popup.getGitHubUserName(), popup.getGitHubPassWord(), popup.getGitHubLabels());
-    }
-
-    @FXML
-    private void suggestNewChildTerm(ActionEvent e) {
-        if (getSelectedTerm() == null) {
-            logger.error("Select a term before creating GitHub issue");
-            PopUps.showInfoMessage("Please select an HPO term before creating GitHub issue",
-                    "Error: No HPO Term selected");
-            return;
-        } else {
-            selectedTerm = getSelectedTerm().getValue().term;
-        }
-        GitHubPopup popup = new GitHubPopup(selectedTerm, true);
-        initializeGitHubLabelsIfNecessary();
-        popup.setLabels(model.getGithublabels());
-        popup.setupGithubUsernamePassword(githubUsername, githubPassword);
-        popup.displayWindow(primarystage);
-        String githubissue = popup.retrieveGitHubIssue();
-        if (githubissue == null) {
-            logger.trace("got back null github issue");
-            return;
-        }
-        String title = String.format("Suggesting new child term of \"%s\"", selectedTerm.getName());
-        postGitHubIssue(githubissue, title, popup.getGitHubUserName(), popup.getGitHubPassWord(), popup.getGitHubLabels());
-    }
-
-    @FXML
-    private void suggestNewAnnotation(ActionEvent e) {
-        if (getSelectedTerm() == null) {
-            logger.error("Select a term before creating GitHub issue");
-            PopUps.showInfoMessage("Please select an HPO term before creating GitHub issue",
-                    "Error: No HPO Term selected");
-            return;
-        } else {
-            selectedTerm = getSelectedTerm().getValue().term;
-        }
-        if (!currentMode.equals(mode.NEW_ANNOTATION)) {
-            PopUps.showInfoMessage("Please select a disease and then a new HPO term before using this option",
-                    "Error: No disease selected");
-            return;
-        }
-        selectedTerm = getSelectedTerm().getValue().term;
-        if (selectedDisease == null) {
-            PopUps.showInfoMessage("Please select a disease and then a new HPO term before using this option",
-                    "Error: No disease selected");
-            return;
-        }
-        GitHubPopup popup = new GitHubPopup(selectedTerm, selectedDisease);
-        initializeGitHubLabelsIfNecessary();
-        popup.setLabels(model.getGithublabels());
-        popup.setupGithubUsernamePassword(githubUsername, githubPassword);
-        popup.displayWindow(primarystage);
-        String githubissue = popup.retrieveGitHubIssue();
-        if (githubissue == null) {
-            logger.trace("got back null GitHub issue");
-            return;
-        }
-        String title = String.format("New annotation suggestion for %s", selectedDisease.getDiseaseName());
-        postGitHubIssue(githubissue, title, popup.getGitHubUserName(), popup.getGitHubPassWord(), popup.getGitHubLabels());
-    }
-
-    @FXML
-    private void reportMistakenAnnotation(ActionEvent e) {
-        if (getSelectedTerm() == null) {
-            logger.error("Select a term before creating GitHub issue");
-            PopUps.showInfoMessage("Please select an HPO term before creating GitHub issue",
-                    "Error: No HPO Term selected");
-            return;
-        } else {
-            selectedTerm = getSelectedTerm().getValue().term;
-        }
-        if (!currentMode.equals(mode.NEW_ANNOTATION)) {
-            PopUps.showInfoMessage("Please select a disease and then a new HPO term before using this option",
-                    "Error: No disease selected");
-            return;
-        }
-        selectedTerm = getSelectedTerm().getValue().term;
-        if (selectedDisease == null) {
-            PopUps.showInfoMessage("Please select a disease and then a new HPO term before using this option",
-                    "Error: No disease selected");
-            return;
-        }
-        GitHubPopup popup = new GitHubPopup(selectedTerm, selectedDisease, true);
-        initializeGitHubLabelsIfNecessary();
-        popup.setLabels(model.getGithublabels());
-        popup.setupGithubUsernamePassword(githubUsername, githubPassword);
-        popup.displayWindow(primarystage);
-        String githubissue = popup.retrieveGitHubIssue();
-        if (githubissue == null) {
-            logger.trace("got back null GitHub issue");
-            return;
-        }
-        String title = String.format("Erroneous annotation for %s", selectedDisease.getDiseaseName());
-        postGitHubIssue(githubissue, title, popup.getGitHubUserName(), popup.getGitHubPassWord());
-    }
-
-    @FXML
-    private void postGitHubIssue(String message, String title, String uname, String pword) {
-        GitHubPoster poster = new GitHubPoster(uname, pword, title, message);
-        this.githubUsername = uname;
-        this.githubPassword = pword;
-        try {
-            poster.postIssue();
-        } catch (HPOWorkbenchException he) {
-            PopUps.showException("GitHub error", "Bad Request (400): Could not post issue", he);
-        } catch (Exception ex) {
-            PopUps.showException("GitHub error", "GitHub error: Could not post issue", ex);
-            return;
-        }
-        String response = poster.getHttpResponse();
-        PopUps.showInfoMessage(
-                String.format("Created issue for %s\nServer response: %s", selectedTerm.getName(), response), "Created new issue");
-
-    }
-
-    @FXML
-    private void postGitHubIssue(String message, String title, String uname, String pword, List<String> labels) {
-        GitHubPoster poster = new GitHubPoster(uname, pword, title, message);
-        this.githubUsername = uname;
-        this.githubPassword = pword;
-        if (labels != null && !labels.isEmpty()) {
-            poster.setLabel(labels);
-        }
-        try {
-            poster.postIssue();
-        } catch (HPOWorkbenchException he) {
-            PopUps.showException("GitHub error", "Bad Request (400): Could not post issue", he);
-        } catch (Exception ex) {
-            PopUps.showException("GitHub error", "GitHub error: Could not post issue", ex);
-            return;
-        }
-        String response = poster.getHttpResponse();
-        PopUps.showInfoMessage(
-                String.format("Created issue for %s\nServer response: %s", selectedTerm.getName(), response), "Created new issue");
-
+      // NO-OP
     }
 
     /** Show the help dialog */
@@ -1040,104 +273,10 @@ public class MainController {
         e.consume();
     }
 
-    /**
-     * Get the children of "term"
-     * @param term HPO Term of interest
-     * @return children of term (not including term itself).
-     */
-    private Set<HpoTerm> getTermChildren(HpoTerm term) {
-        HpoOntology ontology = optionalResources.getHpoOntology();
-        if (ontology==null) {
-            PopUps.showInfoMessage("Error: Could not initialize HPO Ontology","ERROR");
-            return new HashSet<>(); // return empty set
-        }
-        TermId parentTermId = term.getId();
-        Set<TermId> childrenIds = getChildTerms(ontology,parentTermId,false);
-        Set<HpoTerm> kids = new HashSet<>();
-        childrenIds.forEach(tid ->{HpoTerm ht = ontology.getTermMap().get(tid); kids.add(ht);});
-        return kids;
-    }
-
-    /**
-     * Get the parents of "term"
-     * @param term HPO Term of interest
-     * @return parents of term (not including term itself).
-     */
-    private Set<HpoTerm> getTermParents(HpoTerm term) {
-        HpoOntology ontology = optionalResources.getHpoOntology();
-        if (ontology==null) {
-            PopUps.showInfoMessage("Error: Could not initialize HPO Ontology","ERROR");
-            return new HashSet<>(); // return empty set
-        }
-        Set<TermId> parentIds = getParentTerms(ontology,term.getId(),false);
-        Set<HpoTerm> eltern = new HashSet<>();
-        parentIds.forEach(tid ->{HpoTerm ht = ontology.getTermMap().get(tid); eltern.add(ht);});
-        return eltern;
-    }
-
-    private boolean existsPathFromRoot(HpoTerm term) {
-        HpoOntology ontology = optionalResources.getHpoOntology();
-        if (ontology==null) {
-            PopUps.showInfoMessage("Error: Could not initialize HPO Ontology","ERROR");
-            return false;
-        }
-        TermId rootId = ontology.getRootTermId();
-        TermId tid = term.getId();
-        return existsPath(ontology,tid,rootId);
-    }
 
     /** Determines the behavior of the app. Are we browsing HPO terms, diseases, or suggesting new annotations? */
     enum mode {
         BROWSE_HPO, BROWSE_DISEASE, NEW_ANNOTATION
-    }
-
-    /**
-     * Inner class that defines a bridge between hierarchy of {@link HpoTerm}s and {@link TreeItem}s of the
-     * {@link TreeView}.
-     */
-    class HpoTermTreeItem extends TreeItem<HpoTermWrapper> {
-
-        /** List used for caching of the children of this term */
-        private ObservableList<TreeItem<HpoTermWrapper>> childrenList;
-
-        /**
-         * Default & only constructor for the TreeItem.
-         *
-         * @param term {@link HpoTerm} that is represented by this TreeItem
-         */
-        HpoTermTreeItem(HpoTermWrapper term) {
-            super(term);
-        }
-
-        /**
-         * Check that the {@link HpoTerm} that is represented by this TreeItem is a leaf term as described below.
-         * <p>
-         * {@inheritDoc}
-         */
-        @Override
-        public boolean isLeaf() {
-            return getTermChildren(getValue().term).size() == 0;
-        }
-
-
-        /**
-         * Get list of children of the {@link HpoTerm} that is represented by this TreeItem.
-         * {@inheritDoc}
-         */
-        @Override
-        public ObservableList<TreeItem<HpoTermWrapper>> getChildren() {
-            if (childrenList == null) {
-                // logger.debug(String.format("Getting children for term %s", getValue().term.getName()));
-                childrenList = FXCollections.observableArrayList();
-                Set<HpoTerm> children = getTermChildren(getValue().term);
-                children.stream()
-                        .sorted(Comparator.comparing(HpoTerm::getName))
-                        .map(term -> new HpoTermTreeItem(new HpoTermWrapper(term)))
-                        .forEach(childrenList::add);
-                super.getChildren().setAll(childrenList);
-            }
-            return super.getChildren();
-        }
     }
 
 }

--- a/hpowbgui/src/main/java/org/monarchinitiative/hpoworkbench/controller/MainController.java
+++ b/hpowbgui/src/main/java/org/monarchinitiative/hpoworkbench/controller/MainController.java
@@ -68,7 +68,6 @@ public class MainController {
         this.properties = properties;
         this.primaryStage = primaryStage;
         this.hpoWorkbenchDir = hpoWorkbenchDir;
-        logger.trace("CTOR optionsl="+optionalResources.toString());
     }
 
     public static String getVersion() {
@@ -79,7 +78,7 @@ public class MainController {
         } catch (Exception e) {
             // do nothing
         }
-        if (version == null) version = "0.1.14"; // this works on a maven build but needs to be reassigned in intellij
+        if (version == null) version = "0.2.1"; // this works on a maven build but needs to be reassigned in intellij
         return version;
     }
 
@@ -175,13 +174,11 @@ public class MainController {
         window.setTitle("MONDO download");
         window.setScene(scene);
 
-        logger.trace("mondo url = " +  properties.getProperty("mondo.obo.url"));
-        logger.trace("mondo FN = " +  PlatformUtil.MONDO_OBO_FILENAME);
+        //TODO the following is necessary because redirect is not working somehow
         String MONDO_URL_HACK="https://osf.io/e87hn/download";
 
         Task mondodownload = new Downloader(dirpath, MONDO_URL_HACK, PlatformUtil.MONDO_OBO_FILENAME);
         pb.progressProperty().bind(mondodownload.progressProperty());
-
 
         window.show();
         mondodownload.setOnSucceeded(event -> {

--- a/hpowbgui/src/main/java/org/monarchinitiative/hpoworkbench/controller/MainController.java
+++ b/hpowbgui/src/main/java/org/monarchinitiative/hpoworkbench/controller/MainController.java
@@ -25,6 +25,7 @@ import org.monarchinitiative.hpoworkbench.io.HPOParser;
 import org.monarchinitiative.hpoworkbench.io.MondoParser;
 import org.monarchinitiative.hpoworkbench.resources.OptionalResources;
 import org.monarchinitiative.phenol.base.PhenolException;
+import org.monarchinitiative.phenol.ontology.data.Ontology;
 
 import javax.inject.Named;
 import java.io.File;
@@ -67,6 +68,7 @@ public class MainController {
         this.properties = properties;
         this.primaryStage = primaryStage;
         this.hpoWorkbenchDir = hpoWorkbenchDir;
+        logger.trace("CTOR optionsl="+optionalResources.toString());
     }
 
     public static String getVersion() {
@@ -187,7 +189,9 @@ public class MainController {
             logger.trace(String.format("Successfully downloaded mondo to %s", dirpath));
             String mondoOboPath = dirpath + File.separator + PlatformUtil.MONDO_OBO_FILENAME;
             try {
-                optionalResources.setMondoOntology(new MondoParser(mondoOboPath).getMondo());
+                MondoParser parser = new MondoParser(mondoOboPath);
+                Ontology mondo =parser.getMondo();
+                optionalResources.setMondoOntology(mondo);
                 properties.setProperty("mondo.obo.path", mondoOboPath);
             } catch (PhenolException pe) {
                 PopUps.showException("ERROR","Could not parse Mondo obo file", pe);

--- a/hpowbgui/src/main/java/org/monarchinitiative/hpoworkbench/controller/MondoController.java
+++ b/hpowbgui/src/main/java/org/monarchinitiative/hpoworkbench/controller/MondoController.java
@@ -250,7 +250,7 @@ public final class MondoController {
         if (dbxlst==null) return null;
         for (Dbxref dbx : dbxlst) {
             if (dbx.getName().startsWith("Orphanet:"))
-                return dbx.getName();
+                return dbx.getName().replaceAll("Orphanet","ORPHA");
         }
         return null;
     }
@@ -264,23 +264,14 @@ public final class MondoController {
         if (treeItem == null)
             return;
 
-        Model mod = hpoController.getModel();
-        if (mod==null) {
-            mod =new Model(optionalResources.getHpoOntology(), optionalResources.getIndirectAnnotMap(),
-                    optionalResources.getDirectAnnotMap());
-        }
-
         GenericTerm mondoTerm = treeItem.getValue().term;
         String omim=getOMIMid(mondoTerm);
-        String orpha= getOrphanetid(mondoTerm).replaceAll("Orphanet","ORPHA");
+        String orpha= getOrphanetid(mondoTerm);
 
-
-        String termID = mondoTerm.getId().getIdWithPrefix();
         Map<String, HpoDisease> disease2AnnotationMap = optionalResources.getDisease2AnnotationMap();
-        HpoDisease omimDisease=null;
-        HpoDisease orphaDisease=null;
-        omimDisease=disease2AnnotationMap.get(omim);
-        orphaDisease=disease2AnnotationMap.get(orpha);
+
+        HpoDisease omimDisease=disease2AnnotationMap.get(omim);
+        HpoDisease orphaDisease=disease2AnnotationMap.get(orpha);
         debugDisease(omimDisease);
         debugDisease(orphaDisease);
 

--- a/hpowbgui/src/main/java/org/monarchinitiative/hpoworkbench/controller/MondoController.java
+++ b/hpowbgui/src/main/java/org/monarchinitiative/hpoworkbench/controller/MondoController.java
@@ -20,6 +20,7 @@ import org.monarchinitiative.hpoworkbench.model.Model;
 import org.monarchinitiative.hpoworkbench.resources.OptionalResources;
 import org.monarchinitiative.phenol.formats.generic.GenericRelationship;
 import org.monarchinitiative.phenol.formats.generic.GenericTerm;
+import org.monarchinitiative.phenol.formats.hpo.HpoAnnotation;
 import org.monarchinitiative.phenol.formats.hpo.HpoDisease;
 import org.monarchinitiative.phenol.formats.hpo.HpoTerm;
 import org.monarchinitiative.phenol.ontology.data.Dbxref;
@@ -273,12 +274,16 @@ public final class MondoController {
         String omim=getOMIMid(mondoTerm);
         String orpha= getOrphanetid(mondoTerm).replaceAll("Orphanet","ORPHA");
 
+
         String termID = mondoTerm.getId().getIdWithPrefix();
         Map<String, HpoDisease> disease2AnnotationMap = optionalResources.getDisease2AnnotationMap();
         HpoDisease omimDisease=null;
         HpoDisease orphaDisease=null;
         omimDisease=disease2AnnotationMap.get(omim);
         orphaDisease=disease2AnnotationMap.get(orpha);
+        debugDisease(omimDisease);
+        debugDisease(orphaDisease);
+
         if (omimDisease ==null || orphaDisease == null) {
             logger.warn("Could not init diseases");
             int c = 0;
@@ -329,6 +334,16 @@ public final class MondoController {
                 }
             }
         });
+
+    }
+
+    private void debugDisease(HpoDisease disease) {
+        System.err.println("DEBUG DISEASE PRINT MONDO CONTROLLER");
+        System.err.println(disease.getName() +" ["+disease.getDatabase()+":"+disease.getDiseaseDatabaseId()+"]");
+        List<HpoAnnotation> termlist = disease.getPhenotypicAbnormalities();
+        for (HpoAnnotation annot : termlist) {
+            System.err.println("\t" + annot.toString());
+        }
 
     }
 

--- a/hpowbgui/src/main/java/org/monarchinitiative/hpoworkbench/controller/MondoController.java
+++ b/hpowbgui/src/main/java/org/monarchinitiative/hpoworkbench/controller/MondoController.java
@@ -2,8 +2,11 @@ package org.monarchinitiative.hpoworkbench.controller;
 
 import javafx.application.Platform;
 import javafx.beans.binding.BooleanBinding;
+import javafx.beans.value.ChangeListener;
+import javafx.beans.value.ObservableValue;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import javafx.concurrent.Worker;
 import javafx.fxml.FXML;
 import javafx.scene.control.*;
 import javafx.scene.web.WebEngine;
@@ -13,12 +16,21 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.monarchinitiative.hpoworkbench.gui.PopUps;
 import org.monarchinitiative.hpoworkbench.gui.WidthAwareTextFields;
+import org.monarchinitiative.hpoworkbench.model.Model;
 import org.monarchinitiative.hpoworkbench.resources.OptionalResources;
 import org.monarchinitiative.phenol.formats.generic.GenericRelationship;
 import org.monarchinitiative.phenol.formats.generic.GenericTerm;
+import org.monarchinitiative.phenol.formats.hpo.HpoDisease;
 import org.monarchinitiative.phenol.formats.hpo.HpoTerm;
+import org.monarchinitiative.phenol.ontology.data.Dbxref;
+import org.monarchinitiative.phenol.ontology.data.ImmutableTermId;
 import org.monarchinitiative.phenol.ontology.data.Ontology;
 import org.monarchinitiative.phenol.ontology.data.TermId;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+import org.w3c.dom.events.EventListener;
+import org.w3c.dom.events.EventTarget;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -39,8 +51,13 @@ public final class MondoController {
 
     private final OptionalResources optionalResources;
 
+    private final TermId MONDO_ROOT_ID=ImmutableTermId.constructWithPrefix("MONDO:0000001");
+
     /** Unused, but still required. */
     private final File hpoWorkbenchDir;
+    private static final String EVENT_TYPE_CLICK = "click";
+    private static final String EVENT_TYPE_MOUSEOVER = "mouseover";
+    private static final String EVENT_TYPE_MOUSEOUT = "mouseclick";
 
     /**
      * Application-specific properties (not the System properties!) defined in the 'application.properties' file that
@@ -83,6 +100,8 @@ public final class MondoController {
     /** The MONDO term that is currently selected in the Browser window. */
     private GenericTerm selectedTerm = null;
 
+    private HpoController hpoController;
+
     /** Tree hierarchy of the ontology is presented here. */
     @FXML
     private TreeView<GenericTermWrapper> mondoOntologyTreeView;
@@ -104,11 +123,13 @@ public final class MondoController {
 
     @Inject
     public MondoController(OptionalResources optionalResources, Properties properties,
-                           @Named("mainWindow") Stage primaryStage, @Named("hpoWorkbenchDir") File hpoWorkbenchDir) {
+                           @Named("mainWindow") Stage primaryStage, @Named("hpoWorkbenchDir") File hpoWorkbenchDir,
+                           HpoController hpocon) {
         this.optionalResources = optionalResources;
         this.properties = properties;
         this.primaryStage = primaryStage;
         this.hpoWorkbenchDir = hpoWorkbenchDir;
+        this.hpoController=hpocon;
     }
 
     @FXML
@@ -169,9 +190,14 @@ public final class MondoController {
             mondoOntologyTreeView.setRoot(null);
             return;
         }
-        TermId rootId = ontology.getRootTermId();
+        TermId rootId = ontology.getRootTermId(); // TODO not working
+        rootId= ImmutableTermId.constructWithPrefix("MONDO:0000001");
         logger.trace("root id = " + rootId.getIdWithPrefix());
         GenericTerm rootTerm = ontology.getTermMap().get(rootId);
+        if (rootTerm==null) {
+            logger.error("Mondo root term was null");
+            return;
+        }
         logger.trace("RootTerm is " + rootTerm.toString());
         TreeItem<GenericTermWrapper> root = new MondoController.GenericTermTreeItem(new GenericTermWrapper(rootTerm));
         root.setExpanded(true);
@@ -185,7 +211,7 @@ public final class MondoController {
                     }
                     GenericTermWrapper w = newValue.getValue();
                     TreeItem item = new MondoController.GenericTermTreeItem(w);
-                    // updateDescription(item);
+                    updateMondoDescription(item);
                 });
         // create Map for lookup of the terms in the ontology based on their Name
         ontology.getTermMap().values().forEach(term -> {
@@ -202,6 +228,108 @@ public final class MondoController {
                     "<body><p>Click on MONDO term in the tree browser to display additional " +
                     "information</p></body></html>");
         });
+    }
+
+
+
+    private String getOMIMid(GenericTerm gterm) {
+        List<Dbxref> dbxlst=gterm.getXrefs();
+        if (dbxlst==null) return null;
+        for (Dbxref dbx : dbxlst) {
+//           logger.trace("Name=" + dbx.getName());
+//           logger.trace("Description = "+ dbx.getDescription());
+           if (dbx.getName().startsWith("OMIM:"))
+               return dbx.getName();
+        }
+        return null;
+    }
+
+    private String getOrphanetid(GenericTerm gterm) {
+        List<Dbxref> dbxlst=gterm.getXrefs();
+        if (dbxlst==null) return null;
+        for (Dbxref dbx : dbxlst) {
+            if (dbx.getName().startsWith("Orphanet:"))
+                return dbx.getName();
+        }
+        return null;
+    }
+
+    /**
+     * Update content of the {@link #infoWebView} with currently selected {@link HpoTerm}.
+     *
+     * @param treeItem currently selected {@link TreeItem} containing {@link HpoTerm}
+     */
+    private void updateMondoDescription(TreeItem<GenericTermWrapper> treeItem) {
+        if (treeItem == null)
+            return;
+
+        Model mod = hpoController.getModel();
+        if (mod==null) {
+            mod =new Model(optionalResources.getHpoOntology(), optionalResources.getIndirectAnnotMap(),
+                    optionalResources.getDirectAnnotMap());
+        }
+
+        GenericTerm mondoTerm = treeItem.getValue().term;
+        String omim=getOMIMid(mondoTerm);
+        String orpha= getOrphanetid(mondoTerm).replaceAll("Orphanet","ORPHA");
+
+        String termID = mondoTerm.getId().getIdWithPrefix();
+        Map<String, HpoDisease> disease2AnnotationMap = optionalResources.getDisease2AnnotationMap();
+        HpoDisease omimDisease=null;
+        HpoDisease orphaDisease=null;
+        omimDisease=disease2AnnotationMap.get(omim);
+        orphaDisease=disease2AnnotationMap.get(orpha);
+        if (omimDisease ==null || orphaDisease == null) {
+            logger.warn("Could not init diseases");
+            int c = 0;
+            for (String dis : disease2AnnotationMap.keySet()) {
+                logger.warn("example name " + dis);
+                if (c++>10) break;
+            }
+        } else {
+            logger.trace("Got mim " + omimDisease.toString());
+            logger.trace("Got orph " + orphaDisease.toString());
+        }
+
+
+        String content = MondoHtmlPageGenerator.getHTML(mondoTerm, omimDisease,orphaDisease, optionalResources.getHpoOntology());
+        infoWebEngine.loadContent(content);
+        infoWebEngine.getLoadWorker().stateProperty().addListener(new ChangeListener<Worker.State>() {
+            @Override
+            public void changed(ObservableValue ov, Worker.State oldState, Worker.State newState) {
+                if (newState == Worker.State.SUCCEEDED) {
+                    org.w3c.dom.events.EventListener listener = new EventListener() {
+                        @Override
+                        public void handleEvent(org.w3c.dom.events.Event ev) {
+                            String domEventType = ev.getType();
+                            // System.err.println("EventType FROM updateHPO: " + domEventType);
+                            if (domEventType.equals(EVENT_TYPE_CLICK)) {
+                                String href = ((Element) ev.getTarget()).getAttribute("href");
+                                // System.out.println("HREF "+href);
+                                if (href.equals("http://www.human-phenotype-ontology.org")) {
+                                    return; // the external link is taken care of by the Webengine
+                                    // therefore, we do not need to do anything special here
+                                }
+                                // The following line is necessary because sometimes multiple events are triggered
+                                // and we get a "stray" HPO-related link that does not belong here.
+                                if (href.startsWith("HP:")) return;
+
+                                logger.trace("Got click from webview");
+                            }
+                        }
+                    };
+
+                    Document doc = infoWebView.getEngine().getDocument();
+                    NodeList nodeList = doc.getElementsByTagName("a");
+                    for (int i = 0; i < nodeList.getLength(); i++) {
+                        ((EventTarget) nodeList.item(i)).addEventListener(EVENT_TYPE_CLICK, listener, false);
+                        //((EventTarget) nodeList.item(i)).addEventListener(EVENT_TYPE_MOUSEOVER, listener, false);
+                        //((EventTarget) nodeList.item(i)).addEventListener(EVENT_TYPE_MOUSEOVER, listener, false);
+                    }
+                }
+            }
+        });
+
     }
 
 
@@ -233,9 +361,8 @@ public final class MondoController {
             PopUps.showInfoMessage("Error: Could not initialize Mondo Ontology", "ERROR");
             return false;
         }
-        TermId rootId = ontology.getRootTermId();
         TermId tid = term.getId();
-        return existsPath(ontology, tid, rootId);
+        return existsPath(ontology, tid, MONDO_ROOT_ID);
     }
 
 
@@ -282,6 +409,19 @@ public final class MondoController {
             logger.warn(String.format("Unable to find the path from %s to %s", rootTerm.toString(), term.getName()));
         }
         selectedTerm = term;
+    }
+
+    @FXML
+    public void goButtonAction() {
+        TermId tid = labelsAndMondoIds.get(searchTextField.getText());
+        GenericTerm term = optionalResources.getMondoOntology().getTermMap().get(tid);
+        if (term==null) {
+            PopUps.showInfoMessage("Warning","Could not find ontology term for search result");
+            return;
+        }
+        expandUntilTerm(term);
+        TreeItem titem = new TreeItem(new GenericTermWrapper(term));
+        updateMondoDescription(titem);
     }
 
 

--- a/hpowbgui/src/main/java/org/monarchinitiative/hpoworkbench/controller/MondoController.java
+++ b/hpowbgui/src/main/java/org/monarchinitiative/hpoworkbench/controller/MondoController.java
@@ -116,7 +116,7 @@ public final class MondoController {
 
         // this binding evaluates to true, if ontology or annotations files are missing (null)
         BooleanBinding mondoResourceIsMissing = optionalResources.mondoResourceMissing();
-
+    logger.error("Initializing MondoController, missing = " + mondoResourceIsMissing.toString());
         hpoTermRadioButton.disableProperty().bind(mondoResourceIsMissing);
         diseaseRadioButton.disableProperty().bind(mondoResourceIsMissing);
         newAnnotationRadioButton.disableProperty().bind(mondoResourceIsMissing);

--- a/hpowbgui/src/main/java/org/monarchinitiative/hpoworkbench/controller/MondoController.java
+++ b/hpowbgui/src/main/java/org/monarchinitiative/hpoworkbench/controller/MondoController.java
@@ -116,7 +116,7 @@ public final class MondoController {
 
         // this binding evaluates to true, if ontology or annotations files are missing (null)
         BooleanBinding mondoResourceIsMissing = optionalResources.mondoResourceMissing();
-    logger.error("Initializing MondoController, missing = " + mondoResourceIsMissing.toString());
+        logger.error("Initializing MondoController, missing = " + mondoResourceIsMissing.toString());
         hpoTermRadioButton.disableProperty().bind(mondoResourceIsMissing);
         diseaseRadioButton.disableProperty().bind(mondoResourceIsMissing);
         newAnnotationRadioButton.disableProperty().bind(mondoResourceIsMissing);
@@ -138,6 +138,7 @@ public final class MondoController {
             } else { // invalidate model and anything in the background. Controls should be disabled automatically
                 deactivate();
             }
+            System.out.println("MONDO LISTEBNER old="+oldValue+" new="+newValue);
         }));
 
 
@@ -169,7 +170,9 @@ public final class MondoController {
             return;
         }
         TermId rootId = ontology.getRootTermId();
+        logger.trace("root id = " + rootId.getIdWithPrefix());
         GenericTerm rootTerm = ontology.getTermMap().get(rootId);
+        logger.trace("RootTerm is " + rootTerm.toString());
         TreeItem<GenericTermWrapper> root = new MondoController.GenericTermTreeItem(new GenericTermWrapper(rootTerm));
         root.setExpanded(true);
         mondoOntologyTreeView.setShowRoot(false);

--- a/hpowbgui/src/main/java/org/monarchinitiative/hpoworkbench/controller/MondoHtmlPageGenerator.java
+++ b/hpowbgui/src/main/java/org/monarchinitiative/hpoworkbench/controller/MondoHtmlPageGenerator.java
@@ -1,0 +1,191 @@
+package org.monarchinitiative.hpoworkbench.controller;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.monarchinitiative.hpoworkbench.annotation.AnnotationMerger;
+import org.monarchinitiative.hpoworkbench.annotation.CategoryMerge;
+import org.monarchinitiative.hpoworkbench.annotation.HpoCategory;
+import org.monarchinitiative.hpoworkbench.annotation.TermSubClassPair;
+import org.monarchinitiative.hpoworkbench.model.DiseaseModel;
+import org.monarchinitiative.phenol.formats.generic.GenericTerm;
+import org.monarchinitiative.phenol.formats.hpo.HpoDisease;
+import org.monarchinitiative.phenol.formats.hpo.HpoOntology;
+import org.monarchinitiative.phenol.formats.hpo.HpoTerm;
+import org.monarchinitiative.phenol.ontology.data.Dbxref;
+import org.monarchinitiative.phenol.ontology.data.TermId;
+import org.monarchinitiative.phenol.ontology.data.TermSynonym;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Convenience class to generate HTML code to display data about a MONDO entry.
+ * @author <a href="mailto:peter.robinson@jax.org">Peter Robinson</a>
+ */
+public class MondoHtmlPageGenerator {
+    private static final Logger logger = LogManager.getLogger();
+
+
+    private final static String EMPTY_STRING="";
+
+    private static final String HTML_TEMPLATE = "<!DOCTYPE html>" +
+            "<html lang=\"en\"><head>" +
+            "<style>%s</style>\n" +
+            "<meta charset=\"UTF-8\"><title>Mondo browser</title></head>" +
+            "<body>" +
+            "<h1>%s</h1>" +
+            "<p><b>ID:</b> %s</p>" +
+            "<p><b>Definition:</b> %s</p>" +
+            "<p><b>Dbxref:</b> %s</p>" +
+            "<p><b>Synonyms:</b> %s</p>" +
+            "%s\n" +
+            "</body></html>";
+
+    private static final String CSS = "body {\n" +
+            "  font: normal medium/1.4 sans-serif;\n" +
+            "}\n" +
+            "table {\n" +
+            "  border-collapse: collapse;\n" +
+            "  width: 100%;\n" +
+            "}\n" +
+            "th, td {\n" +
+            "  padding: 0.25rem;\n" +
+            "  text-align: left;\n" +
+            "  border: 1px solid #ccc;\n" +
+            "}\n" +
+            "tbody tr:nth-child(odd) {\n" +
+            "  background: #eee;\n" +
+            "}";
+
+
+
+    static String getHTML(GenericTerm term, HpoDisease omim, HpoDisease orpha, HpoOntology ontology) {
+        if (omim==null) {
+            logger.warn("Attempt to getHTML for null OMIM disease");
+        }
+        if (orpha==null) {
+            logger.warn("Attempt to getHTML for null Orphanet disease");
+        }
+        AnnotationMerger merger=new AnnotationMerger(omim,orpha, ontology);
+        merger.merge();
+        Map<HpoCategory,CategoryMerge> catmap = merger.getMergedCategoryMap();
+
+        String termID = term.getId().getIdWithPrefix();
+        String synonyms = (term.getSynonyms() == null) ? EMPTY_STRING : term.getSynonyms().stream().map(TermSynonym::getValue)
+                .collect(Collectors.joining("; "));
+        String definition = (term.getDefinition() == null) ? EMPTY_STRING : term.getDefinition();
+        List<Dbxref>  dbxlist = term.getXrefs();
+        String comment = (dbxlist == null||dbxlist.isEmpty()) ?
+                EMPTY_STRING :
+                dbxlist.stream().map(Dbxref::getName).collect(Collectors.joining("; "));
+        logger.trace("About to call getMergerTable, catmap size is "+catmap.size());
+        String tabula = getMergerTable(catmap,ontology);
+        return String.format(HTML_TEMPLATE, CSS, term.getName(), termID, definition, comment, synonyms, tabula);
+    }
+
+
+    private static String getTableFramework(String title, String disease1name, String disease2name) {
+        return String.format("  <table class=\"zebra\">\n" +
+                "    <caption  style=\"color:#222;text-shadow:0px 1px 2px #555;font-size:24px;\">%s</caption>\n" +
+                "    <thead>\n" +
+                "      <tr>\n" +
+                "        <th>Id</th><th>%s</th><th>%s</th>\n" +
+                "      </tr>\n" +
+                "    </thead>\n" +
+                "    <tfoot>\n" +
+                "      <tr>\n" +
+                "        <td colspan=\"3\">More information: <a href=\"http://www.human-phenotype-ontology.org\">HPO Website</a></td>\n" +
+                "      </tr>\n" +
+                "    </tfoot>", title, disease1name,disease2name);
+    }
+
+    private static String getBothDieasesRows(List<TermId> termIdList, HpoOntology ontology ) {
+        if (termIdList==null || termIdList.isEmpty()) return EMPTY_STRING;
+        StringBuilder sb = new StringBuilder();
+        for (TermId tid : termIdList) {
+            HpoTerm term = ontology.getTermMap().get(tid);
+            String row = String.format("<tr>\n" +
+                            "        <td rowspan=\"2\">Terms shared by both diseases</td>\n" +
+                            "        <td rowspan=\"2\"><a href=\"%s\">%s [%s]</a></td>\n" +
+                            "      </tr>\n",
+                    term.getId().getIdWithPrefix(),
+                    term.getName(),
+                    term.getId().getIdWithPrefix());
+            sb.append(row);
+        }
+        return sb.toString();
+    }
+
+    private static String getSubclassRows(CategoryMerge catmerge, HpoOntology ontology) {
+        String diseaseName1=catmerge.getDisease1name();
+        String diseaseName2=catmerge.getDisease2name();
+        StringBuilder sb = new StringBuilder();
+
+        List<TermSubClassPair> sclasspairs = catmerge.getD1subclassOfd2();
+        if (sclasspairs==null || sclasspairs.isEmpty()) {
+            sb.append(EMPTY_STRING);
+        } else {
+            for (TermSubClassPair tscp : sclasspairs) {
+                TermId t1 = tscp.getSubTid();
+                TermId t2 = tscp.getSuperTid();
+                String label1 = ontology.getTermMap().get(t1).getName();
+                String label2 = ontology.getTermMap().get(t2).getName();
+                sb.append(String.format("         <td rowspan=\"2\">s [%s] (%s)is subclass of %s [%s] (%s)</td>\n",
+                        label1, t1.getIdWithPrefix(), diseaseName1,
+                        label2, t2.getIdWithPrefix(), diseaseName2));
+            }
+        }
+        sclasspairs = catmerge.getD2subclassOfd1();
+        if (sclasspairs==null || sclasspairs.isEmpty()) {
+            sb.append(EMPTY_STRING);
+        } else {
+            for (TermSubClassPair tscp : sclasspairs) {
+                TermId t2 = tscp.getSubTid();
+                TermId t1 = tscp.getSuperTid();
+                String label1 = ontology.getTermMap().get(t1).getName();
+                String label2 = ontology.getTermMap().get(t2).getName();
+                sb.append(String.format("<td rowspan=\"2\">%s [%s] (%s) is subclass of %s [%s] (%s)</td>",
+                        label2, t2.getIdWithPrefix(), diseaseName2,
+                        label1, t1.getIdWithPrefix(), diseaseName1));
+            }
+        }
+        return sb.toString();
+    }
+
+    private static String getOnlyOneDiseaseRows(CategoryMerge catmerge, HpoOntology ontology){
+        String diseaseName1=catmerge.getDisease1name();
+        String diseaseName2=catmerge.getDisease2name();
+        StringBuilder sb = new StringBuilder();
+        for (TermId t1 : catmerge.getDisease1onlyTerms()) {
+            String label = ontology.getTermMap().get(t1).getName();
+            sb.append(String.format("<td rowspan=\"2\">%s only: %s [%s]</td>",diseaseName1,label,t1.getIdWithPrefix()));
+        }
+        for (TermId t2 : catmerge.getDisease2onlyTerms()) {
+            String label = ontology.getTermMap().get(t2).getName();
+            sb.append(String.format("<td rowspan=\"2\">%s only: %s [%s]</td>",diseaseName2,label,t2.getIdWithPrefix()));
+        }
+        return sb.toString();
+    }
+
+
+
+
+    private static String getMergerTable(Map<HpoCategory,CategoryMerge> catmap, HpoOntology ontology) {
+        StringBuilder sb = new StringBuilder();
+        for (HpoCategory cat : catmap.keySet()) {
+            CategoryMerge catmerge = catmap.get(cat);
+            logger.trace("Get tanle for cat "+cat.getLabel());
+            String disease1name = catmerge.getDisease1name();
+            String disease2name = catmerge.getDisease2name();
+            String title = cat.getLabel();//String.format(template, cat.getLabel(), cat.getNumberOfAnnotations());
+            sb.append(getTableFramework(title, disease1name,disease2name));
+            List<TermId> termIdList = catmerge.getDisease1onlyTerms();
+            sb.append(getBothDieasesRows(termIdList,ontology));
+            sb.append(getSubclassRows(catmerge,ontology));
+            sb.append(getOnlyOneDiseaseRows(catmerge,ontology));
+            sb.append("\n");
+        }
+        return sb.toString();
+    }
+}

--- a/hpowbgui/src/main/java/org/monarchinitiative/hpoworkbench/controller/MondoHtmlPageGenerator.java
+++ b/hpowbgui/src/main/java/org/monarchinitiative/hpoworkbench/controller/MondoHtmlPageGenerator.java
@@ -5,8 +5,7 @@ import org.apache.logging.log4j.Logger;
 import org.monarchinitiative.hpoworkbench.annotation.AnnotationMerger;
 import org.monarchinitiative.hpoworkbench.annotation.CategoryMerge;
 import org.monarchinitiative.hpoworkbench.annotation.HpoCategory;
-import org.monarchinitiative.hpoworkbench.annotation.TermSubClassPair;
-import org.monarchinitiative.hpoworkbench.model.DiseaseModel;
+import org.monarchinitiative.hpoworkbench.annotation.SubClassTermPair;
 import org.monarchinitiative.phenol.formats.generic.GenericTerm;
 import org.monarchinitiative.phenol.formats.hpo.HpoDisease;
 import org.monarchinitiative.phenol.formats.hpo.HpoOntology;
@@ -122,16 +121,16 @@ public class MondoHtmlPageGenerator {
         String diseaseName2=catmerge.getDisease2name();
         StringBuilder sb = new StringBuilder();
 
-        List<TermSubClassPair> sclasspairs = catmerge.getD1subclassOfd2();
+        List<SubClassTermPair> sclasspairs = catmerge.getD1subclassOfd2();
         if (sclasspairs==null || sclasspairs.isEmpty()) {
             sb.append(EMPTY_STRING);
         } else {
-            for (TermSubClassPair tscp : sclasspairs) {
+            for (SubClassTermPair tscp : sclasspairs) {
                 TermId t1 = tscp.getSubTid();
                 TermId t2 = tscp.getSuperTid();
                 String label1 = ontology.getTermMap().get(t1).getName();
                 String label2 = ontology.getTermMap().get(t2).getName();
-                sb.append(String.format("         <td rowspan=\"2\">s [%s] (%s)is subclass of %s [%s] (%s)</td>\n",
+                sb.append(String.format("         <td rowspan=\"2\">s [%s] (%s)is subclass of %s [%s]</td>\n",
                         label1, t1.getIdWithPrefix(), diseaseName1,
                         label2, t2.getIdWithPrefix(), diseaseName2));
             }
@@ -140,7 +139,7 @@ public class MondoHtmlPageGenerator {
         if (sclasspairs==null || sclasspairs.isEmpty()) {
             sb.append(EMPTY_STRING);
         } else {
-            for (TermSubClassPair tscp : sclasspairs) {
+            for (SubClassTermPair tscp : sclasspairs) {
                 TermId t2 = tscp.getSubTid();
                 TermId t1 = tscp.getSuperTid();
                 String label1 = ontology.getTermMap().get(t1).getName();

--- a/hpowbgui/src/main/java/org/monarchinitiative/hpoworkbench/controller/StatusController.java
+++ b/hpowbgui/src/main/java/org/monarchinitiative/hpoworkbench/controller/StatusController.java
@@ -53,6 +53,7 @@ public final class StatusController {
         optionalResources.hpoOntologyProperty().addListener(listener);
         optionalResources.indirectAnnotMapProperty().addListener(listener);
         optionalResources.directAnnotMapProperty().addListener(listener);
+        optionalResources.mondoOntologyProperty().addListener(listener);
 
         checkAll();
     }

--- a/hpowbgui/src/main/java/org/monarchinitiative/hpoworkbench/controller/StatusController.java
+++ b/hpowbgui/src/main/java/org/monarchinitiative/hpoworkbench/controller/StatusController.java
@@ -11,6 +11,8 @@ import org.monarchinitiative.hpoworkbench.resources.OptionalResources;
 import javax.inject.Inject;
 import java.util.ResourceBundle;
 
+enum MessageType {INFO, WARNING, ERROR}
+
 /**
  * This class is a controller of the bottom part of the main dialog window. Status messages are displayed here, as
  * well as the copyright.
@@ -64,10 +66,14 @@ public final class StatusController {
         } else if (optionalResources.getDirectAnnotMap() == null || // annotations file is missing
                 optionalResources.getIndirectAnnotMap() == null) {
             publishMessage(resourceBundle.getString("status.download.annotations"), MessageType.ERROR);
-        } else { // since we check only 2 resources, we should be fine here
+        } else if (optionalResources.getMondoOntology() == null) {
+            publishMessage(resourceBundle.getString("status.download.mondo"), MessageType.ERROR);
+        } else { // since we check only 2 resources, we should be
+            // fine here
             publishMessage(resourceBundle.getString("status.all.set"), MessageType.INFO);
         }
     }
+
 
     /**
      * Post information message to the status bar.
@@ -122,6 +128,4 @@ public final class StatusController {
 
         return label;
     }
-
-    enum MessageType {INFO, WARNING, ERROR}
 }

--- a/hpowbgui/src/main/java/org/monarchinitiative/hpoworkbench/gui/PlatformUtil.java
+++ b/hpowbgui/src/main/java/org/monarchinitiative/hpoworkbench/gui/PlatformUtil.java
@@ -16,7 +16,7 @@ public class PlatformUtil {
 
     public static final String MONDO_OBO_FILENAME = "mondo.obo";
 
-    public static final String HPO_ANNOTATIONS_FILENAME = "phenotype_annotation.tab";
+    public static final String HPO_ANNOTATIONS_FILENAME = "phenotype.hpoa";
 
     public static final String HPO_WORKBENCH_SETTINGS_FILENAME = "application.properties";
 

--- a/hpowbgui/src/main/java/org/monarchinitiative/hpoworkbench/model/Model.java
+++ b/hpowbgui/src/main/java/org/monarchinitiative/hpoworkbench/model/Model.java
@@ -16,6 +16,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+/**
+ * This class coordinates the data on diseases and annotations.
+ * @author <a href="mailto:peter.robinson@jax.org">Peter Robinson</a>
+ */
 public class Model {
     private static final Logger logger = LogManager.getLogger();
     private final TermPrefix HP_PREFIX = new ImmutableTermPrefix("HP");
@@ -28,18 +32,12 @@ public class Model {
 
     private List<String> githublabels=new ArrayList<>();
 
-//    public Model(){
-//        initPaths();
-//        importData();
-//    }
 
     public Model(HpoOntology ontology, Map<TermId, List<DiseaseModel>> annotMap,
                  Map<TermId, List<DiseaseModel>> directAnnotMap) {
         this.ontology = ontology;
         this.annotmap = annotMap;
         this.directAnnotMap = directAnnotMap;
-//        this.pathToAnnotationFile=phenoAnnotationPath;
-//        importData();
     }
 
     public void setGithublabels(List<String> lab) { this.githublabels=lab; }
@@ -47,35 +45,6 @@ public class Model {
     public List<String> getGithublabels() { return githublabels; }
 
     public boolean hasLabels(){ return githublabels!=null && githublabels.size()>0; }
-
-    @Deprecated
-    private void initPaths() {
-//        this.pathToHpoOboFile=getLocalHPOPath();
-//        this.pathToAnnotationFile=getLocalPhenotypeAnnotationPath();
-    }
-
-    @Deprecated
-    private void importData() {
-//        if (ontology==null) {
-//            if (pathToHpoOboFile==null) {
-//                logger.error("Path to hp.obo was not initialized");
-//                return;
-//            }
-//            HPOParser parser = new HPOParser(pathToHpoOboFile);
-//            this.ontology=parser.getHPO();
-//        }
-//        if (annotmap==null) {
-//            HpoOntology ontology = getHpoOntology();
-//            DirectIndirectHpoAnnotationParser parser = new DirectIndirectHpoAnnotationParser(this.pathToAnnotationFile,ontology);
-//            annotmap=parser.parse();
-//            directAnnotMap=parser.getDirectannotmap();
-//        }
-//        logger.trace("Ingested annot map with size="+annotmap.size());
-
-    }
-
-
-
 
     public List<DiseaseModel> getDiseaseAnnotations(String hpoTermId, DiseaseModel.database dbase) {
         List<DiseaseModel> diseases=new ArrayList<>();
@@ -139,15 +108,7 @@ public class Model {
 
 
 
-    public HpoOntology getOntology() {
-//        if (ontology==null) {
-//            if (pathToHpoOboFile==null) {
-//                logger.error("Path to hp.obo was not initialized");
-//                return null;
-//            }
-//            HPOParser parser = new HPOParser(pathToHpoOboFile);
-//            this.ontology=parser.getHPO();
-//        }
+    public HpoOntology getHpoOntology() {
         return ontology;
     }
 

--- a/hpowbgui/src/main/java/org/monarchinitiative/hpoworkbench/resources/OptionalResources.java
+++ b/hpowbgui/src/main/java/org/monarchinitiative/hpoworkbench/resources/OptionalResources.java
@@ -48,7 +48,8 @@ public final class OptionalResources {
 
     private final ObjectProperty<HpoOntology> hpoOntology = new SimpleObjectProperty<>(this, "hpoOntology", null);
 
-    private final ObjectProperty<Ontology<GenericTerm, GenericRelationship>> mondoOntology = new SimpleObjectProperty<>(this, "mondoOntology", null);
+    private final ObjectProperty<Ontology<GenericTerm, GenericRelationship>> mondoOntology
+            = new SimpleObjectProperty<>(this, "mondoOntology", null);
 
     private final ObjectProperty<Map<TermId, List<DiseaseModel>>> indirectAnnotMap =
             new SimpleObjectProperty<>(this, "indirectAnnotMap", null);
@@ -63,7 +64,8 @@ public final class OptionalResources {
                 hpoOntologyProperty(), indirectAnnotMapProperty(), directAnnotMapProperty());
 
         mondoResourceIsMissing = Bindings.createBooleanBinding(() -> Stream.of(mondoOntologyProperty(),
-                indirectAnnotMapProperty(), directAnnotMapProperty()).anyMatch(op -> op.get() == null),
+                indirectAnnotMapProperty(),
+                directAnnotMapProperty()).anyMatch(op -> op.get() == null),
                 mondoOntologyProperty(), indirectAnnotMapProperty(), directAnnotMapProperty());
     }
 
@@ -121,8 +123,12 @@ public final class OptionalResources {
         return mondoOntology.get();
     }
 
-    public void setMondoOntology(Ontology mondoOntology) {
-        this.mondoOntology.set(ResourceValidators.mondoResourceValidator().isValid(mondoOntology) ? mondoOntology : null);
+    public void setMondoOntology(Ontology<GenericTerm, GenericRelationship> mondoOntology) {
+        if (this.mondoOntology==null) {
+            System.err.println("[ERROR] MONDO ONTOLOGTY NULL");
+            return;
+        }
+        this.mondoOntology.set(mondoOntology);
     }
 
     public ObjectProperty<Ontology<GenericTerm, GenericRelationship>> mondoOntologyProperty() {

--- a/hpowbgui/src/main/java/org/monarchinitiative/hpoworkbench/resources/OptionalResources.java
+++ b/hpowbgui/src/main/java/org/monarchinitiative/hpoworkbench/resources/OptionalResources.java
@@ -9,6 +9,7 @@ import javafx.scene.control.Tab;
 import org.monarchinitiative.hpoworkbench.model.DiseaseModel;
 import org.monarchinitiative.phenol.formats.generic.GenericRelationship;
 import org.monarchinitiative.phenol.formats.generic.GenericTerm;
+import org.monarchinitiative.phenol.formats.hpo.HpoDisease;
 import org.monarchinitiative.phenol.formats.hpo.HpoOntology;
 import org.monarchinitiative.phenol.ontology.data.Ontology;
 import org.monarchinitiative.phenol.ontology.data.TermId;
@@ -57,6 +58,9 @@ public final class OptionalResources {
     private final ObjectProperty<Map<TermId, List<DiseaseModel>>> directAnnotMap =
             new SimpleObjectProperty<>(this, "directAnnotMap", null);
 
+    private final ObjectProperty<Map<String, HpoDisease>> disease2annotationMap =
+            new SimpleObjectProperty<>(this,"disease2annotationMap", null);
+
     public OptionalResources() {
         hpoResourceIsMissing = Bindings.createBooleanBinding(() -> Stream.of(hpoOntologyProperty(),
                 indirectAnnotMapProperty(),
@@ -95,6 +99,13 @@ public final class OptionalResources {
         this.indirectAnnotMap.set(indirectAnnotMap);
     }
 
+    public void setDisease2annotationMap(Map<String, HpoDisease> d2amap) {
+        this.disease2annotationMap.set(d2amap);
+    }
+    public ObjectProperty<Map<String, HpoDisease>> disease2annotationMapProperty() { return disease2annotationMap; }
+
+    public Map<String, HpoDisease> getDisease2AnnotationMap() { return disease2annotationMap.get(); }
+
     public ObjectProperty<Map<TermId, List<DiseaseModel>>> indirectAnnotMapProperty() {
         return indirectAnnotMap;
     }
@@ -125,7 +136,7 @@ public final class OptionalResources {
 
     public void setMondoOntology(Ontology<GenericTerm, GenericRelationship> mondoOntology) {
         if (this.mondoOntology==null) {
-            System.err.println("[ERROR] MONDO ONTOLOGTY NULL");
+            System.err.println("[ERROR] MONDO ONTOLOGY NULL");
             return;
         }
         this.mondoOntology.set(mondoOntology);

--- a/hpowbgui/src/main/java/org/monarchinitiative/hpoworkbench/resources/OptionalResources.java
+++ b/hpowbgui/src/main/java/org/monarchinitiative/hpoworkbench/resources/OptionalResources.java
@@ -5,6 +5,7 @@ import javafx.beans.binding.Bindings;
 import javafx.beans.binding.BooleanBinding;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleObjectProperty;
+import javafx.scene.control.Tab;
 import org.monarchinitiative.hpoworkbench.model.DiseaseModel;
 import org.monarchinitiative.phenol.formats.generic.GenericRelationship;
 import org.monarchinitiative.phenol.formats.generic.GenericTerm;
@@ -33,11 +34,21 @@ import java.util.stream.Stream;
  */
 public final class OptionalResources {
 
-    private final BooleanBinding someResourceIsMissing;
+    /**
+     * This binding evaluates as true when a resource required for a {@link Tab} controlled by
+     * {@link org.monarchinitiative.hpoworkbench.controller.MondoController} is missing.
+     */
+    private final BooleanBinding mondoResourceIsMissing;
+
+    /**
+     * This binding evaluates as true when a resource required for a {@link Tab} controlled by
+     * {@link org.monarchinitiative.hpoworkbench.controller.HpoController} is missing.
+     */
+    private final BooleanBinding hpoResourceIsMissing;
 
     private final ObjectProperty<HpoOntology> hpoOntology = new SimpleObjectProperty<>(this, "hpoOntology", null);
 
-    private final ObjectProperty<Ontology<GenericTerm, GenericRelationship>> mondoOntology = new SimpleObjectProperty<>(this,"mondoOntology", null);
+    private final ObjectProperty<Ontology<GenericTerm, GenericRelationship>> mondoOntology = new SimpleObjectProperty<>(this, "mondoOntology", null);
 
     private final ObjectProperty<Map<TermId, List<DiseaseModel>>> indirectAnnotMap =
             new SimpleObjectProperty<>(this, "indirectAnnotMap", null);
@@ -46,10 +57,14 @@ public final class OptionalResources {
             new SimpleObjectProperty<>(this, "directAnnotMap", null);
 
     public OptionalResources() {
-        someResourceIsMissing = Bindings.createBooleanBinding(() -> Stream.of(hpoOntologyProperty(),
+        hpoResourceIsMissing = Bindings.createBooleanBinding(() -> Stream.of(hpoOntologyProperty(),
                 indirectAnnotMapProperty(),
                 directAnnotMapProperty()).anyMatch(op -> op.get() == null),
                 hpoOntologyProperty(), indirectAnnotMapProperty(), directAnnotMapProperty());
+
+        mondoResourceIsMissing = Bindings.createBooleanBinding(() -> Stream.of(mondoOntologyProperty(),
+                indirectAnnotMapProperty(), directAnnotMapProperty()).anyMatch(op -> op.get() == null),
+                mondoOntologyProperty(), indirectAnnotMapProperty(), directAnnotMapProperty());
     }
 
     /**
@@ -57,8 +72,17 @@ public final class OptionalResources {
      *
      * @return {@link BooleanBinding}
      */
-    public BooleanBinding someResourceMissing() {
-        return someResourceIsMissing;
+    public BooleanBinding hpoResourceMissing() {
+        return hpoResourceIsMissing;
+    }
+
+    /**
+     * This binding evaluates to false, if any of mondoOntology, annotMap or directAnnotMap are missing/null.
+     *
+     * @return {@link BooleanBinding}
+     */
+    public BooleanBinding mondoResourceMissing() {
+        return mondoResourceIsMissing;
     }
 
     public Map<TermId, List<DiseaseModel>> getIndirectAnnotMap() {
@@ -89,18 +113,20 @@ public final class OptionalResources {
         return hpoOntology.get();
     }
 
-    public Ontology<GenericTerm, GenericRelationship> getMondoOntology() { return mondoOntology.get(); }
-
     public void setHpoOntology(HpoOntology hpoOntology) {
         this.hpoOntology.set(ResourceValidators.ontologyResourceValidator().isValid(hpoOntology) ? hpoOntology : null);
     }
 
-    public ObjectProperty<Ontology<GenericTerm, GenericRelationship>> mondoOntologyProperty() {
-        return mondoOntology;
+    public Ontology<GenericTerm, GenericRelationship> getMondoOntology() {
+        return mondoOntology.get();
     }
 
     public void setMondoOntology(Ontology mondoOntology) {
         this.mondoOntology.set(ResourceValidators.mondoResourceValidator().isValid(mondoOntology) ? mondoOntology : null);
+    }
+
+    public ObjectProperty<Ontology<GenericTerm, GenericRelationship>> mondoOntologyProperty() {
+        return mondoOntology;
     }
 
     public ObjectProperty<HpoOntology> hpoOntologyProperty() {

--- a/hpowbgui/src/main/resources/application.properties
+++ b/hpowbgui/src/main/resources/application.properties
@@ -5,6 +5,8 @@ mondo.obo.url = https://osf.io/e87hn/download
 
 #hpo.obo.path =
 
+#mondo.obo.path =
+
 # URL pointing to the HPO annotations file
 hpo.phenotype.annotations.url = http://compbio.charite.de/jenkins/job/hpo.annotations.2018/lastSuccessfulBuild/artifact/misc_2018/phenotype.hpoa
 

--- a/hpowbgui/src/main/resources/application.properties
+++ b/hpowbgui/src/main/resources/application.properties
@@ -6,6 +6,6 @@ mondo.obo.url = https://osf.io/e87hn/download
 #hpo.obo.path =
 
 # URL pointing to the HPO annotations file
-hpo.phenotype.annotations.url = http://compbio.charite.de/jenkins/job/hpo.annotations/lastStableBuild/artifact/misc/phenotype_annotation.tab
+hpo.phenotype.annotations.url = http://compbio.charite.de/jenkins/job/hpo.annotations.2018/lastSuccessfulBuild/artifact/misc_2018/phenotype.hpoa
 
 #hpo.annotations.path =

--- a/hpowbgui/src/main/resources/application.properties
+++ b/hpowbgui/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 # URL pointing to the most recent version of HPO obo file
-hpo.obo.url = https://raw.githubusercontent.com/obophenotype/human-phenotype-hpoOntology/master/hp.obo
+hpo.obo.url = https://raw.githubusercontent.com/obophenotype/human-phenotype-ontology/master/hp.obo
 # URL pointing to a stable release version of the Monarch Disease Ontology
 mondo.obo.url = https://osf.io/e87hn/download
 

--- a/hpowbgui/src/main/resources/fxml/hpo.fxml
+++ b/hpowbgui/src/main/resources/fxml/hpo.fxml
@@ -1,0 +1,139 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.geometry.*?>
+<?import javafx.scene.control.*?>
+<?import javafx.scene.layout.*?>
+<?import javafx.scene.web.WebView?>
+<SplitPane id="splitPaneHpo" dividerPositions="0.5" focusTraversable="true" xmlns="http://javafx.com/javafx/8.0.121" xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.monarchinitiative.hpoworkbench.controller.HpoController">
+
+    <VBox BorderPane.alignment="CENTER">
+        <Label styleClass="bluelabel" stylesheets="@../css/style.css" text="Browse HPO Terms or Diseases">
+            <VBox.margin>
+                <Insets bottom="5.0" left="15.0" top="5.0" />
+            </VBox.margin>
+        </Label>
+        <HBox>
+            <VBox.margin>
+                <Insets bottom="5.0" />
+            </VBox.margin>
+            <RadioButton fx:id="hpoTermRadioButton" mnemonicParsing="false" text="HPO Terms" userData="hpo">
+                <HBox.margin>
+                    <Insets left="5.0" top="10.0" />
+                </HBox.margin>
+            </RadioButton>
+            <RadioButton fx:id="diseaseRadioButton" mnemonicParsing="false" text="Diseases" userData="disease">
+                <HBox.margin>
+                    <Insets left="5.0" right="5.0" top="10.0" />
+                </HBox.margin>
+            </RadioButton>
+            <RadioButton fx:id="newAnnotationRadioButton" mnemonicParsing="false" text="New Annotation" userData="newannotation">
+                <HBox.margin>
+                    <Insets left="5.0" right="5.0" top="10.0" />
+                </HBox.margin>
+            </RadioButton>
+        </HBox>
+        <HBox maxHeight="-Infinity" minHeight="-Infinity" minWidth="-Infinity" VBox.vgrow="ALWAYS">
+            <TextField fx:id="searchTextField" maxHeight="30.0" maxWidth="1.7976931348623157E308" minHeight="30.0" minWidth="320.0" promptText="autocomplete HPO term...">
+                <HBox.margin>
+                    <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
+                </HBox.margin>
+            </TextField>
+            <Button fx:id="goButton" minHeight="30.0" minWidth="-Infinity" mnemonicParsing="false" onAction="#goButtonAction" styleClass="Button" stylesheets="@../css/style.css" text="Go" textOverrun="CLIP">
+                <tooltip>
+                    <Tooltip text="tell me what to do" />
+                </tooltip>
+                <HBox.margin>
+                    <Insets bottom="5.0" left="5.0" right="10.0" top="5.0" />
+                </HBox.margin>
+            </Button>
+        </HBox>
+        <TreeView fx:id="ontologyTreeView" maxHeight="1.7976931348623157E308" minWidth="-Infinity" VBox.vgrow="ALWAYS">
+            <VBox.margin>
+                <Insets left="5.0" right="5.0" top="5.0" />
+            </VBox.margin>
+        </TreeView>
+    </VBox>
+
+    <AnchorPane>
+        <WebView fx:id="infoWebView" maxHeight="-1.0" maxWidth="-1.0" minHeight="-1.0" minWidth="-1.0" prefHeight="-1.0" prefWidth="-1.0" AnchorPane.bottomAnchor="130.0" AnchorPane.leftAnchor="5.0" AnchorPane.rightAnchor="5.0" AnchorPane.topAnchor="5.0" />
+        <HBox prefHeight="130.0" AnchorPane.bottomAnchor="5.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0">
+            <GridPane>
+                <columnConstraints>
+                    <ColumnConstraints hgrow="SOMETIMES" />
+                    <ColumnConstraints hgrow="SOMETIMES" minWidth="-Infinity" />
+                </columnConstraints>
+                <rowConstraints>
+                    <RowConstraints minHeight="10.0" vgrow="SOMETIMES" />
+                    <RowConstraints minHeight="10.0" vgrow="SOMETIMES" />
+                    <RowConstraints minHeight="10.0" vgrow="SOMETIMES" />
+                </rowConstraints>
+                <HBox.margin>
+                    <Insets bottom="5.0" left="20.0" right="20.0" top="5.0" />
+                </HBox.margin>
+                <Button fx:id="exportHierarchicalSummaryButton" minWidth="210.0" mnemonicParsing="false" onAction="#exportHierarchicalSummary" styleClass="Button" stylesheets="@../css/style.css" text="Export hierarchical Summary">
+                    <GridPane.margin>
+                        <Insets right="5.0" />
+                    </GridPane.margin>
+                </Button>
+                <Button fx:id="exportToExcelButton" minWidth="210.0" mnemonicParsing="false" onAction="#exportToExcel" styleClass="Button" stylesheets="@../css/style.css" text="Export hpoOntology as Excel file" GridPane.rowIndex="1">
+                    <GridPane.margin>
+                        <Insets right="5.0" />
+                    </GridPane.margin>
+                </Button>
+                <Button fx:id="suggestCorrectionToTermButton" minWidth="210.0" mnemonicParsing="false" onAction="#suggestCorrectionToTerm" styleClass="Button" stylesheets="@../css/style.css" text="Suggest correction " GridPane.columnIndex="1">
+                    <GridPane.margin>
+                        <Insets left="5.0" right="5.0" />
+                    </GridPane.margin>
+                </Button>
+                <Button fx:id="suggestNewChildTermButton" minWidth="210.0" mnemonicParsing="false" onAction="#suggestNewChildTerm" styleClass="Button" stylesheets="@../css/style.css" text="Suggest new child term" GridPane.columnIndex="1" GridPane.rowIndex="1">
+                    <GridPane.margin>
+                        <Insets left="5.0" right="5.0" />
+                    </GridPane.margin>
+                </Button>
+                <Button fx:id="suggestNewAnnotationButton" minWidth="210.0" mnemonicParsing="false" onAction="#suggestNewAnnotation" styleClass="Button" stylesheets="@../css/style.css" text="Suggest new annotation" GridPane.rowIndex="2">
+                    <GridPane.margin>
+                        <Insets right="5.0" />
+                    </GridPane.margin>
+                </Button>
+                <Button fx:id="reportMistakenAnnotationButton" minWidth="210.0" mnemonicParsing="false" onAction="#reportMistakenAnnotation" styleClass="Button" stylesheets="@../css/style.css" text="Report mistaken annotation" GridPane.columnIndex="1" GridPane.rowIndex="2">
+                    <GridPane.margin>
+                        <Insets left="5.0" right="5.0" />
+                    </GridPane.margin>
+                </Button>
+            </GridPane>
+            <VBox alignment="CENTER_LEFT" HBox.hgrow="ALWAYS">
+                <VBox>
+                    <Label styleClass="mylabel" stylesheets="@../css/style.css" text="Disease databases:">
+                        <VBox.margin>
+                            <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
+                        </VBox.margin>
+                    </Label>
+                    <HBox prefHeight="100.0" prefWidth="200.0">
+                        <RadioButton fx:id="allDatabaseButton" mnemonicParsing="false" text="All" userData="all">
+                            <HBox.margin>
+                                <Insets left="5.0" right="5.0" />
+                            </HBox.margin>
+                        </RadioButton>
+                        <RadioButton fx:id="orphanetButton" mnemonicParsing="false" text="Orphanet" userData="orphanet">
+                            <HBox.margin>
+                                <Insets left="5.0" right="5.0" />
+                            </HBox.margin>
+                        </RadioButton>
+                        <RadioButton fx:id="omimButton" mnemonicParsing="false" text="OMIM" userData="omim">
+                            <HBox.margin>
+                                <Insets left="5.0" right="5.0" />
+                            </HBox.margin>
+                        </RadioButton>
+                        <RadioButton fx:id="decipherButton" mnemonicParsing="false" text="DECIPHER" userData="decipher">
+                            <HBox.margin>
+                                <Insets left="5.0" right="5.0" />
+                            </HBox.margin>
+                        </RadioButton>
+                    </HBox>
+                </VBox>
+                <Region VBox.vgrow="SOMETIMES" />
+            </VBox>
+        </HBox>
+    </AnchorPane>
+
+        </SplitPane>

--- a/hpowbgui/src/main/resources/fxml/main.fxml
+++ b/hpowbgui/src/main/resources/fxml/main.fxml
@@ -1,63 +1,35 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<?import javafx.geometry.Insets?>
-<?import javafx.scene.control.Button?>
-<?import javafx.scene.control.Label?>
-<?import javafx.scene.control.Menu?>
-<?import javafx.scene.control.MenuBar?>
-<?import javafx.scene.control.MenuItem?>
-<?import javafx.scene.control.RadioButton?>
-<?import javafx.scene.control.Tab?>
-<?import javafx.scene.control.TabPane?>
-<?import javafx.scene.control.TextField?>
-<?import javafx.scene.control.Tooltip?>
-<?import javafx.scene.control.TreeView?>
-<?import javafx.scene.layout.AnchorPane?>
-<?import javafx.scene.layout.BorderPane?>
-<?import javafx.scene.layout.ColumnConstraints?>
-<?import javafx.scene.layout.GridPane?>
-<?import javafx.scene.layout.HBox?>
-<?import javafx.scene.layout.Region?>
-<?import javafx.scene.layout.RowConstraints?>
-<?import javafx.scene.layout.StackPane?>
-<?import javafx.scene.layout.VBox?>
-<?import javafx.scene.web.WebView?>
-
-
-<?import javafx.scene.control.SplitPane?>
-<BorderPane xmlns="http://javafx.com/javafx/8.0.111" xmlns:fx="http://javafx.com/fxml/1"
-            fx:controller="org.monarchinitiative.hpoworkbench.controller.MainController">
+<?import javafx.scene.control.*?>
+<?import javafx.scene.layout.*?>
+<BorderPane xmlns="http://javafx.com/javafx/8.0.121" xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.monarchinitiative.hpoworkbench.controller.MainController">
     <top>
         <HBox prefHeight="30.0" styleClass="menu-bar" BorderPane.alignment="CENTER">
             <children>
-                <MenuBar minHeight="30.0" minWidth="120.0" prefWidth="120.0" styleClass="mymenu"
-                         stylesheets="@../css/style.css">
+                <MenuBar minHeight="30.0" minWidth="120.0" prefWidth="120.0" styleClass="mymenu" stylesheets="@../css/style.css">
                     <menus>
                         <Menu mnemonicParsing="false" text="File">
                             <items>
-                                <MenuItem mnemonicParsing="false" onAction="#close" text="Quit"/>
+                                <MenuItem mnemonicParsing="false" onAction="#close" text="Quit" />
                             </items>
                         </Menu>
                         <Menu mnemonicParsing="false" text="Edit">
                             <items>
-                                <MenuItem mnemonicParsing="false" onAction="#downloadHPO" text="Download HPO"/>
-                                <MenuItem mnemonicParsing="false" onAction="#downloadHPOAnnotations"
-                                          text="Download HPO annotations"/>
-                                <MenuItem mnemonicParsing="false" onAction="#downloadMondo"
-                                          text="Download Mondo"/>
-                                <MenuItem mnemonicParsing="false" onAction="#importLocalHpObo"
-                                          text="Import local copy of hp.obo"/>
+                                <MenuItem mnemonicParsing="false" onAction="#downloadHPO" text="Download HPO" />
+                                <MenuItem mnemonicParsing="false" onAction="#downloadHPOAnnotations" text="Download HPO annotations" />
+                                <MenuItem mnemonicParsing="false" onAction="#downloadMondo" text="Download Mondo" />
+                                <MenuItem mnemonicParsing="false" onAction="#importLocalHpObo" text="Import local copy of hp.obo" />
                             </items>
                         </Menu>
                     </menus>
                 </MenuBar>
-                <Region minHeight="30.0" styleClass="fx-menubar" HBox.hgrow="ALWAYS"/>
+                <Region minHeight="30.0" styleClass="fx-menubar" HBox.hgrow="ALWAYS" />
                 <MenuBar minHeight="30.0" minWidth="70.0" HBox.hgrow="NEVER">
                     <menus>
                         <Menu mnemonicParsing="false" text="Help">
                             <items>
-                                <MenuItem mnemonicParsing="false" onAction="#helpWindow" text="Help"/>
-                                <MenuItem mnemonicParsing="false" onAction="#aboutWindow" text="About"/>
+                                <MenuItem mnemonicParsing="false" onAction="#helpWindow" text="Help" />
+                                <MenuItem mnemonicParsing="false" onAction="#aboutWindow" text="About" />
                             </items>
                         </Menu>
                     </menus>
@@ -66,234 +38,18 @@
         </HBox>
     </top>
     <center>
-        <TabPane prefHeight="200.0" prefWidth="200.0" tabClosingPolicy="UNAVAILABLE" fx:id="tabPane">
-            <tabs>
-                <Tab text="HPO Browser" fx:id="hpoTab">
-                    <content>
-                        <!--  <BorderPane maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="1200.0"
-                                      prefHeight="700.0" prefWidth="1200.0"> -->
-                        <SplitPane id="splitPaneHorizontal1" focusTraversable="true" prefHeight="400.0"
-                                   prefWidth="600.0">
-
-                            <items>
-                                <VBox BorderPane.alignment="CENTER">
-                                    <children>
-                                        <Label styleClass="bluelabel" stylesheets="@../css/style.css"
-                                               text="Browse HPO Terms or Diseases">
-                                            <VBox.margin>
-                                                <Insets bottom="5.0" left="15.0" top="5.0"/>
-                                            </VBox.margin>
-                                        </Label>
-                                        <HBox>
-                                            <children>
-                                                <RadioButton fx:id="hpoTermRadioButton" mnemonicParsing="false"
-                                                             text="HPO Terms" userData="hpo">
-                                                    <HBox.margin>
-                                                        <Insets left="5.0" top="10.0"/>
-                                                    </HBox.margin>
-                                                </RadioButton>
-                                                <RadioButton fx:id="diseaseRadioButton" mnemonicParsing="false"
-                                                             text="Diseases" userData="disease">
-                                                    <HBox.margin>
-                                                        <Insets left="5.0" right="5.0" top="10.0"/>
-                                                    </HBox.margin>
-                                                </RadioButton>
-                                                <RadioButton fx:id="newAnnotationRadioButton" mnemonicParsing="false"
-                                                             text="New Annotation" userData="newannotation">
-                                                    <HBox.margin>
-                                                        <Insets left="5.0" right="5.0" top="10.0"/>
-                                                    </HBox.margin>
-                                                </RadioButton>
-                                            </children>
-                                            <VBox.margin>
-                                                <Insets bottom="5.0"/>
-                                            </VBox.margin>
-                                        </HBox>
-                                        <HBox maxHeight="-Infinity" minHeight="-Infinity" minWidth="-Infinity"
-                                              VBox.vgrow="ALWAYS">
-                                            <children>
-                                                <TextField fx:id="searchTextField" maxHeight="30.0"
-                                                           maxWidth="1.7976931348623157E308" minHeight="30.0"
-                                                           minWidth="320.0" promptText="autocomplete HPO term...">
-                                                    <HBox.margin>
-                                                        <Insets bottom="5.0" left="5.0" right="5.0" top="5.0"/>
-                                                    </HBox.margin>
-                                                </TextField>
-                                                <Button fx:id="goButton" minHeight="30.0" minWidth="-Infinity"
-                                                        mnemonicParsing="false" onAction="#goButtonAction"
-                                                        styleClass="Button" stylesheets="@../css/style.css" text="Go"
-                                                        textOverrun="CLIP">
-                                                    <tooltip>
-                                                        <Tooltip text="tell me what to do"/>
-                                                    </tooltip>
-                                                    <HBox.margin>
-                                                        <Insets bottom="5.0" left="5.0" right="10.0" top="5.0"/>
-                                                    </HBox.margin>
-                                                </Button>
-                                            </children>
-                                        </HBox>
-                                        <TreeView fx:id="ontologyTreeView" maxHeight="1.7976931348623157E308"
-                                                  minWidth="-Infinity" VBox.vgrow="ALWAYS">
-                                            <VBox.margin>
-                                                <Insets left="5.0" right="5.0" top="5.0"/>
-                                            </VBox.margin>
-                                        </TreeView>
-                                    </children>
-                                </VBox>
-                            </items>
-                            <items>
-
-                                <AnchorPane>
-                                    <children>
-                                        <WebView fx:id="infoWebView" maxHeight="-1.0" maxWidth="-1.0" minHeight="-1.0"
-                                                 minWidth="-1.0" prefHeight="-1.0" prefWidth="-1.0"
-                                                 AnchorPane.bottomAnchor="130.0" AnchorPane.leftAnchor="5.0"
-                                                 AnchorPane.rightAnchor="5.0" AnchorPane.topAnchor="5.0"/>
-                                        <HBox prefHeight="130.0" AnchorPane.bottomAnchor="5.0"
-                                              AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0">
-                                            <children>
-                                                <GridPane>
-                                                    <columnConstraints>
-                                                        <ColumnConstraints hgrow="SOMETIMES"/>
-                                                        <ColumnConstraints hgrow="SOMETIMES" minWidth="-Infinity"/>
-                                                    </columnConstraints>
-                                                    <rowConstraints>
-                                                        <RowConstraints minHeight="10.0" vgrow="SOMETIMES"/>
-                                                        <RowConstraints minHeight="10.0" vgrow="SOMETIMES"/>
-                                                        <RowConstraints minHeight="10.0" vgrow="SOMETIMES"/>
-                                                    </rowConstraints>
-                                                    <children>
-                                                        <Button fx:id="exportHierarchicalSummaryButton" minWidth="210.0"
-                                                                mnemonicParsing="false"
-                                                                onAction="#exportHierarchicalSummary"
-                                                                styleClass="Button" stylesheets="@../css/style.css"
-                                                                text="Export hierarchical Summary">
-                                                            <GridPane.margin>
-                                                                <Insets right="5.0"/>
-                                                            </GridPane.margin>
-                                                        </Button>
-                                                        <Button fx:id="exportToExcelButton" minWidth="210.0"
-                                                                mnemonicParsing="false" onAction="#exportToExcel"
-                                                                styleClass="Button" stylesheets="@../css/style.css"
-                                                                text="Export hpoOntology as Excel file"
-                                                                GridPane.rowIndex="1">
-                                                            <GridPane.margin>
-                                                                <Insets right="5.0"/>
-                                                            </GridPane.margin>
-                                                        </Button>
-                                                        <Button fx:id="suggestCorrectionToTermButton" minWidth="210.0"
-                                                                mnemonicParsing="false"
-                                                                onAction="#suggestCorrectionToTerm" styleClass="Button"
-                                                                stylesheets="@../css/style.css"
-                                                                text="Suggest correction " GridPane.columnIndex="1">
-                                                            <GridPane.margin>
-                                                                <Insets left="5.0" right="5.0"/>
-                                                            </GridPane.margin>
-                                                        </Button>
-                                                        <Button fx:id="suggestNewChildTermButton" minWidth="210.0"
-                                                                mnemonicParsing="false" onAction="#suggestNewChildTerm"
-                                                                styleClass="Button" stylesheets="@../css/style.css"
-                                                                text="Suggest new child term" GridPane.columnIndex="1"
-                                                                GridPane.rowIndex="1">
-                                                            <GridPane.margin>
-                                                                <Insets left="5.0" right="5.0"/>
-                                                            </GridPane.margin>
-                                                        </Button>
-                                                        <Button fx:id="suggestNewAnnotationButton" minWidth="210.0"
-                                                                mnemonicParsing="false" onAction="#suggestNewAnnotation"
-                                                                styleClass="Button" stylesheets="@../css/style.css"
-                                                                text="Suggest new annotation" GridPane.rowIndex="2">
-                                                            <GridPane.margin>
-                                                                <Insets right="5.0"/>
-                                                            </GridPane.margin>
-                                                        </Button>
-                                                        <Button fx:id="reportMistakenAnnotationButton" minWidth="210.0"
-                                                                mnemonicParsing="false"
-                                                                onAction="#reportMistakenAnnotation" styleClass="Button"
-                                                                stylesheets="@../css/style.css"
-                                                                text="Report mistaken annotation"
-                                                                GridPane.columnIndex="1" GridPane.rowIndex="2">
-                                                            <GridPane.margin>
-                                                                <Insets left="5.0" right="5.0"/>
-                                                            </GridPane.margin>
-                                                        </Button>
-                                                    </children>
-                                                    <HBox.margin>
-                                                        <Insets bottom="5.0" left="20.0" right="20.0" top="5.0"/>
-                                                    </HBox.margin>
-                                                </GridPane>
-                                                <VBox alignment="CENTER_LEFT" HBox.hgrow="ALWAYS">
-                                                    <children>
-                                                        <VBox prefHeight="200.0" prefWidth="100.0">
-                                                            <children>
-                                                                <Label styleClass="mylabel"
-                                                                       stylesheets="@../css/style.css"
-                                                                       text="Disease databases:">
-                                                                    <VBox.margin>
-                                                                        <Insets bottom="10.0" left="10.0" right="10.0"
-                                                                                top="10.0"/>
-                                                                    </VBox.margin>
-                                                                </Label>
-                                                                <HBox prefHeight="100.0" prefWidth="200.0">
-                                                                    <children>
-                                                                        <RadioButton fx:id="allDatabaseButton"
-                                                                                     mnemonicParsing="false" text="All"
-                                                                                     userData="all">
-                                                                            <HBox.margin>
-                                                                                <Insets left="5.0" right="5.0"/>
-                                                                            </HBox.margin>
-                                                                        </RadioButton>
-                                                                        <RadioButton fx:id="orphanetButton"
-                                                                                     mnemonicParsing="false"
-                                                                                     text="Orphanet"
-                                                                                     userData="orphanet">
-                                                                            <HBox.margin>
-                                                                                <Insets left="5.0" right="5.0"/>
-                                                                            </HBox.margin>
-                                                                        </RadioButton>
-                                                                        <RadioButton fx:id="omimButton"
-                                                                                     mnemonicParsing="false" text="OMIM"
-                                                                                     userData="omim">
-                                                                            <HBox.margin>
-                                                                                <Insets left="5.0" right="5.0"/>
-                                                                            </HBox.margin>
-                                                                        </RadioButton>
-                                                                        <RadioButton fx:id="decipherButton"
-                                                                                     mnemonicParsing="false"
-                                                                                     text="DECIPHER"
-                                                                                     userData="decipher">
-                                                                            <HBox.margin>
-                                                                                <Insets left="5.0" right="5.0"/>
-                                                                            </HBox.margin>
-                                                                        </RadioButton>
-                                                                    </children>
-                                                                </HBox>
-                                                            </children>
-                                                        </VBox>
-                                                        <Region VBox.vgrow="SOMETIMES"/>
-                                                    </children>
-                                                </VBox>
-                                            </children>
-                                        </HBox>
-                                    </children>
-                                </AnchorPane>
-
-                            </items>
-
-                        </SplitPane>
-                    </content>
-                </Tab>
-                <Tab text="Mondo Browser" fx:id="mondoTab">
-                    <content>
-                        <fx:include source="mondo.fxml"/>
-                    </content>
-                </Tab>
-            </tabs>
+        <TabPane tabClosingPolicy="UNAVAILABLE">
+            <Tab text="Hpo Browser">
+                <fx:include source="hpo.fxml"/>
+            </Tab>
+            <Tab text="Mondo Browser">
+                <fx:include source="mondo.fxml"/>
+            </Tab>
         </TabPane>
     </center>
     <bottom>
         <StackPane fx:id="statusStackPane" BorderPane.alignment="CENTER_LEFT">
-            <fx:include source="status.fxml"/>
+            <fx:include source="status.fxml" />
         </StackPane>
     </bottom>
 </BorderPane>

--- a/hpowbgui/src/main/resources/fxml/mondo.fxml
+++ b/hpowbgui/src/main/resources/fxml/mondo.fxml
@@ -1,217 +1,153 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
+<?import javafx.geometry.*?>
 <?import javafx.scene.control.*?>
 <?import javafx.scene.layout.*?>
-
-<?import javafx.geometry.Insets?>
 <?import javafx.scene.web.WebView?>
-<SplitPane id="splitPaneMondo" focusTraversable="true" prefHeight="400.0"
-           prefWidth="600.0" xmlns="http://javafx.com/javafx/8.0.111"
-           xmlns:fx="http://javafx.com/fxml/1"
-           fx:controller="org.monarchinitiative.hpoworkbench.controller.MondoController">
+<SplitPane id="splitPaneMondo" dividerPositions="0.5" focusTraversable="true" xmlns="http://javafx.com/javafx/8.0.121" xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.monarchinitiative.hpoworkbench.controller.MondoController">
 
-    <items>
-        <VBox BorderPane.alignment="CENTER">
-            <children>
-                <Label styleClass="bluelabel" stylesheets="@../css/style.css"
-                       text="Browse HPO Terms or Diseases">
-                    <VBox.margin>
-                        <Insets bottom="5.0" left="15.0" top="5.0"/>
-                    </VBox.margin>
-                </Label>
-                <HBox>
-                    <children>
-                        <RadioButton fx:id="hpoTermRadioButton" mnemonicParsing="false"
-                                     text="HPO Terms" userData="hpo">
-                            <HBox.margin>
-                                <Insets left="5.0" top="10.0"/>
-                            </HBox.margin>
-                        </RadioButton>
-                        <RadioButton fx:id="diseaseRadioButton" mnemonicParsing="false"
-                                     text="Diseases" userData="disease">
-                            <HBox.margin>
-                                <Insets left="5.0" right="5.0" top="10.0"/>
-                            </HBox.margin>
-                        </RadioButton>
-                        <RadioButton fx:id="newAnnotationRadioButton" mnemonicParsing="false"
-                                     text="New Annotation" userData="newannotation">
-                            <HBox.margin>
-                                <Insets left="5.0" right="5.0" top="10.0"/>
-                            </HBox.margin>
-                        </RadioButton>
-                    </children>
-                    <VBox.margin>
-                        <Insets bottom="5.0"/>
-                    </VBox.margin>
-                </HBox>
-                <HBox maxHeight="-Infinity" minHeight="-Infinity" minWidth="-Infinity"
-                      VBox.vgrow="ALWAYS">
-                    <children>
-                        <TextField fx:id="searchTextField" maxHeight="30.0"
-                                   maxWidth="1.7976931348623157E308" minHeight="30.0"
-                                   minWidth="320.0" promptText="autocomplete HPO term...">
-                            <HBox.margin>
-                                <Insets bottom="5.0" left="5.0" right="5.0" top="5.0"/>
-                            </HBox.margin>
-                        </TextField>
-                        <Button fx:id="goButton" minHeight="30.0" minWidth="-Infinity"
-                                mnemonicParsing="false"
-                                styleClass="Button" stylesheets="@../css/style.css" text="Go"
-                                textOverrun="CLIP">
-                            <tooltip>
-                                <Tooltip text="tell me what to do"/>
-                            </tooltip>
-                            <HBox.margin>
-                                <Insets bottom="5.0" left="5.0" right="10.0" top="5.0"/>
-                            </HBox.margin>
-                        </Button>
-                    </children>
-                </HBox>
-                <TreeView fx:id="mondoOntologyTreeView" maxHeight="1.7976931348623157E308"
-                          minWidth="-Infinity" VBox.vgrow="ALWAYS">
-                    <VBox.margin>
-                        <Insets left="5.0" right="5.0" top="5.0"/>
-                    </VBox.margin>
-                </TreeView>
-            </children>
-        </VBox>
-    </items>
-    <items>
+    <VBox BorderPane.alignment="CENTER">
+        <Label styleClass="bluelabel" stylesheets="@../css/style.css" text="Browse MONDO Terms or Diseases">
+            <VBox.margin>
+                <Insets bottom="5.0" left="15.0" top="5.0" />
+            </VBox.margin>
+        </Label>
+        <HBox>
+            <VBox.margin>
+                <Insets bottom="5.0" />
+            </VBox.margin>
+            <RadioButton fx:id="hpoTermRadioButton" mnemonicParsing="false" text="HPO Terms" userData="hpo">
+                <HBox.margin>
+                    <Insets left="5.0" top="10.0" />
+                </HBox.margin>
+            </RadioButton>
+            <RadioButton fx:id="diseaseRadioButton" mnemonicParsing="false" text="Diseases" userData="disease">
+                <HBox.margin>
+                    <Insets left="5.0" right="5.0" top="10.0" />
+                </HBox.margin>
+            </RadioButton>
+            <RadioButton fx:id="newAnnotationRadioButton" mnemonicParsing="false" text="New Annotation" userData="newannotation">
+                <HBox.margin>
+                    <Insets left="5.0" right="5.0" top="10.0" />
+                </HBox.margin>
+            </RadioButton>
+        </HBox>
+        <HBox maxHeight="-Infinity" minHeight="-Infinity" minWidth="-Infinity" VBox.vgrow="ALWAYS">
+            <TextField fx:id="searchTextField" maxHeight="30.0" maxWidth="1.7976931348623157E308" minHeight="30.0" minWidth="320.0" promptText="autocomplete HPO term...">
+                <HBox.margin>
+                    <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
+                </HBox.margin>
+            </TextField>
+            <Button fx:id="goButton" minHeight="30.0" minWidth="-Infinity" mnemonicParsing="false" styleClass="Button" stylesheets="@../css/style.css" text="Go" textOverrun="CLIP">
+                <tooltip>
+                    <Tooltip text="tell me what to do" />
+                </tooltip>
+                <HBox.margin>
+                    <Insets bottom="5.0" left="5.0" right="10.0" top="5.0" />
+                </HBox.margin>
+            </Button>
+        </HBox>
+        <TreeView fx:id="mondoOntologyTreeView" minWidth="-Infinity" VBox.vgrow="ALWAYS">
+            <VBox.margin>
+                <Insets left="5.0" right="5.0" top="5.0" />
+            </VBox.margin>
+        </TreeView>
+    </VBox>
 
-        <AnchorPane>
-            <children>
-                <WebView fx:id="infoWebView" maxHeight="-1.0" maxWidth="-1.0" minHeight="-1.0"
-                         minWidth="-1.0" prefHeight="-1.0" prefWidth="-1.0"
-                         AnchorPane.bottomAnchor="130.0" AnchorPane.leftAnchor="5.0"
-                         AnchorPane.rightAnchor="5.0" AnchorPane.topAnchor="5.0"/>
-                <HBox prefHeight="130.0" AnchorPane.bottomAnchor="5.0"
-                      AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0">
-                    <children>
-                        <GridPane>
-                            <columnConstraints>
-                                <ColumnConstraints hgrow="SOMETIMES"/>
-                                <ColumnConstraints hgrow="SOMETIMES" minWidth="-Infinity"/>
-                            </columnConstraints>
-                            <rowConstraints>
-                                <RowConstraints minHeight="10.0" vgrow="SOMETIMES"/>
-                                <RowConstraints minHeight="10.0" vgrow="SOMETIMES"/>
-                                <RowConstraints minHeight="10.0" vgrow="SOMETIMES"/>
-                            </rowConstraints>
-                            <children>
-                                <Button fx:id="exportHierarchicalSummaryButton" minWidth="210.0"
-                                        mnemonicParsing="false"
-                                        styleClass="Button" stylesheets="@../css/style.css"
-                                        text="Export hierarchical Summary">
-                                    <GridPane.margin>
-                                        <Insets right="5.0"/>
-                                    </GridPane.margin>
-                                </Button>
-                                <Button fx:id="exportToExcelButton" minWidth="210.0"
-                                        mnemonicParsing="false"
-                                        styleClass="Button" stylesheets="@../css/style.css"
-                                        text="Export hpoOntology as Excel file"
-                                        GridPane.rowIndex="1">
-                                    <GridPane.margin>
-                                        <Insets right="5.0"/>
-                                    </GridPane.margin>
-                                </Button>
-                                <Button fx:id="suggestCorrectionToTermButton" minWidth="210.0"
-                                        mnemonicParsing="false"
-                                        styleClass="Button"
-                                        stylesheets="@../css/style.css"
-                                        text="Suggest correction " GridPane.columnIndex="1">
-                                    <GridPane.margin>
-                                        <Insets left="5.0" right="5.0"/>
-                                    </GridPane.margin>
-                                </Button>
-                                <Button fx:id="suggestNewChildTermButton" minWidth="210.0"
-                                        mnemonicParsing="false"
-                                        styleClass="Button" stylesheets="@../css/style.css"
-                                        text="Suggest new child term" GridPane.columnIndex="1"
-                                        GridPane.rowIndex="1">
-                                    <GridPane.margin>
-                                        <Insets left="5.0" right="5.0"/>
-                                    </GridPane.margin>
-                                </Button>
-                                <Button fx:id="suggestNewAnnotationButton" minWidth="210.0"
-                                        mnemonicParsing="false"
-                                        styleClass="Button" stylesheets="@../css/style.css"
-                                        text="Suggest new annotation" GridPane.rowIndex="2">
-                                    <GridPane.margin>
-                                        <Insets right="5.0"/>
-                                    </GridPane.margin>
-                                </Button>
-                                <Button fx:id="reportMistakenAnnotationButton" minWidth="210.0"
-                                        mnemonicParsing="false"
-                                        styleClass="Button"
-                                        stylesheets="@../css/style.css"
-                                        text="Report mistaken annotation"
-                                        GridPane.columnIndex="1" GridPane.rowIndex="2">
-                                    <GridPane.margin>
-                                        <Insets left="5.0" right="5.0"/>
-                                    </GridPane.margin>
-                                </Button>
-                            </children>
-                            <HBox.margin>
-                                <Insets bottom="5.0" left="20.0" right="20.0" top="5.0"/>
-                            </HBox.margin>
-                        </GridPane>
-                        <VBox alignment="CENTER_LEFT" HBox.hgrow="ALWAYS">
-                            <children>
-                                <VBox prefHeight="200.0" prefWidth="100.0">
-                                    <children>
-                                        <Label styleClass="mylabel"
-                                               stylesheets="@../css/style.css"
-                                               text="Disease databases:">
-                                            <VBox.margin>
-                                                <Insets bottom="10.0" left="10.0" right="10.0"
-                                                        top="10.0"/>
-                                            </VBox.margin>
-                                        </Label>
-                                        <HBox prefHeight="100.0" prefWidth="200.0">
-                                            <children>
-                                                <RadioButton fx:id="allDatabaseButton"
-                                                             mnemonicParsing="false" text="All"
-                                                             userData="all">
-                                                    <HBox.margin>
-                                                        <Insets left="5.0" right="5.0"/>
-                                                    </HBox.margin>
-                                                </RadioButton>
-                                                <RadioButton fx:id="orphanetButton"
-                                                             mnemonicParsing="false"
-                                                             text="Orphanet"
-                                                             userData="orphanet">
-                                                    <HBox.margin>
-                                                        <Insets left="5.0" right="5.0"/>
-                                                    </HBox.margin>
-                                                </RadioButton>
-                                                <RadioButton fx:id="omimButton"
-                                                             mnemonicParsing="false" text="OMIM"
-                                                             userData="omim">
-                                                    <HBox.margin>
-                                                        <Insets left="5.0" right="5.0"/>
-                                                    </HBox.margin>
-                                                </RadioButton>
-                                                <RadioButton fx:id="decipherButton"
-                                                             mnemonicParsing="false"
-                                                             text="DECIPHER"
-                                                             userData="decipher">
-                                                    <HBox.margin>
-                                                        <Insets left="5.0" right="5.0"/>
-                                                    </HBox.margin>
-                                                </RadioButton>
-                                            </children>
-                                        </HBox>
-                                    </children>
-                                </VBox>
-                                <Region VBox.vgrow="SOMETIMES"/>
-                            </children>
-                        </VBox>
-                    </children>
-                </HBox>
-            </children>
-        </AnchorPane>
-
-    </items>
+    <AnchorPane>
+        <children>
+            <WebView fx:id="infoWebView" maxHeight="-1.0" maxWidth="-1.0" minHeight="-1.0" minWidth="-1.0" prefHeight="-1.0" prefWidth="-1.0" AnchorPane.bottomAnchor="130.0" AnchorPane.leftAnchor="5.0" AnchorPane.rightAnchor="5.0" AnchorPane.topAnchor="5.0" />
+            <HBox AnchorPane.bottomAnchor="5.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0">
+                <children>
+                    <GridPane hgap="5.0" vgap="5.0">
+                        <columnConstraints>
+                            <ColumnConstraints hgrow="SOMETIMES" />
+                            <ColumnConstraints hgrow="SOMETIMES" />
+                        </columnConstraints>
+                        <rowConstraints>
+                            <RowConstraints minHeight="10.0" vgrow="SOMETIMES" />
+                            <RowConstraints minHeight="10.0" vgrow="SOMETIMES" />
+                            <RowConstraints minHeight="10.0" vgrow="SOMETIMES" />
+                        </rowConstraints>
+                        <children>
+                            <Button fx:id="exportHierarchicalSummaryButton" minWidth="210.0" mnemonicParsing="false" styleClass="Button" stylesheets="@../css/style.css" text="Export hierarchical Summary">
+                                <GridPane.margin>
+                                    <Insets right="5.0" />
+                                </GridPane.margin>
+                        <padding>
+                           <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
+                        </padding>
+                            </Button>
+                            <Button fx:id="exportToExcelButton" minWidth="210.0" mnemonicParsing="false" styleClass="Button" stylesheets="@../css/style.css" text="Export hpoOntology as Excel file" GridPane.rowIndex="1">
+                                <GridPane.margin>
+                                    <Insets right="5.0" />
+                                </GridPane.margin>
+                            </Button>
+                            <Button fx:id="suggestCorrectionToTermButton" minWidth="210.0" mnemonicParsing="false" styleClass="Button" stylesheets="@../css/style.css" text="Suggest correction " GridPane.columnIndex="1">
+                                <GridPane.margin>
+                                    <Insets left="5.0" right="5.0" />
+                                </GridPane.margin>
+                            </Button>
+                            <Button fx:id="suggestNewChildTermButton" minWidth="210.0" mnemonicParsing="false" styleClass="Button" stylesheets="@../css/style.css" text="Suggest new child term" GridPane.columnIndex="1" GridPane.rowIndex="1">
+                                <GridPane.margin>
+                                    <Insets left="5.0" right="5.0" />
+                                </GridPane.margin>
+                            </Button>
+                            <Button fx:id="suggestNewAnnotationButton" minWidth="210.0" mnemonicParsing="false" styleClass="Button" stylesheets="@../css/style.css" text="Suggest new annotation" GridPane.rowIndex="2">
+                                <GridPane.margin>
+                                    <Insets right="5.0" />
+                                </GridPane.margin>
+                            </Button>
+                            <Button fx:id="reportMistakenAnnotationButton" minWidth="210.0" mnemonicParsing="false" styleClass="Button" stylesheets="@../css/style.css" text="Report mistaken annotation" GridPane.columnIndex="1" GridPane.rowIndex="2">
+                                <GridPane.margin>
+                                    <Insets left="5.0" right="5.0" />
+                                </GridPane.margin>
+                            </Button>
+                        </children>
+                        <HBox.margin>
+                            <Insets bottom="5.0" left="20.0" right="20.0" top="5.0" />
+                        </HBox.margin>
+                    </GridPane>
+                    <VBox alignment="CENTER_LEFT" HBox.hgrow="ALWAYS">
+                        <children>
+                            <VBox VBox.vgrow="SOMETIMES">
+                                <children>
+                                    <Label styleClass="mylabel" stylesheets="@../css/style.css" text="Disease databases:">
+                                        <VBox.margin>
+                                            <Insets bottom="10.0" left="10.0" right="10.0" top="10.0" />
+                                        </VBox.margin>
+                                    </Label>
+                                    <HBox VBox.vgrow="SOMETIMES">
+                                        <children>
+                                            <RadioButton fx:id="allDatabaseButton" mnemonicParsing="false" text="All" userData="all">
+                                                <HBox.margin>
+                                                    <Insets left="5.0" right="5.0" />
+                                                </HBox.margin>
+                                            </RadioButton>
+                                            <RadioButton fx:id="orphanetButton" mnemonicParsing="false" text="Orphanet" userData="orphanet">
+                                                <HBox.margin>
+                                                    <Insets left="5.0" right="5.0" />
+                                                </HBox.margin>
+                                            </RadioButton>
+                                            <RadioButton fx:id="omimButton" mnemonicParsing="false" text="OMIM" userData="omim">
+                                                <HBox.margin>
+                                                    <Insets left="5.0" right="5.0" />
+                                                </HBox.margin>
+                                            </RadioButton>
+                                            <RadioButton fx:id="decipherButton" mnemonicParsing="false" text="DECIPHER" userData="decipher">
+                                                <HBox.margin>
+                                                    <Insets left="5.0" right="5.0" />
+                                                </HBox.margin>
+                                            </RadioButton>
+                                        </children>
+                                    </HBox>
+                                </children>
+                            </VBox>
+                        </children>
+                    </VBox>
+                </children>
+            </HBox>
+        </children>
+    </AnchorPane>
 
 </SplitPane>

--- a/hpowbgui/src/main/resources/fxml/mondo.fxml
+++ b/hpowbgui/src/main/resources/fxml/mondo.fxml
@@ -1,10 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<?import javafx.geometry.*?>
-<?import javafx.scene.control.*?>
-<?import javafx.scene.layout.*?>
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.control.Button?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.control.RadioButton?>
+<?import javafx.scene.control.SplitPane?>
+<?import javafx.scene.control.TextField?>
+<?import javafx.scene.control.Tooltip?>
+<?import javafx.scene.control.TreeView?>
+<?import javafx.scene.layout.AnchorPane?>
+<?import javafx.scene.layout.BorderPane?>
+<?import javafx.scene.layout.ColumnConstraints?>
+<?import javafx.scene.layout.GridPane?>
+<?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.RowConstraints?>
+<?import javafx.scene.layout.VBox?>
 <?import javafx.scene.web.WebView?>
-<SplitPane id="splitPaneMondo" dividerPositions="0.5" focusTraversable="true" xmlns="http://javafx.com/javafx/8.0.121" xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.monarchinitiative.hpoworkbench.controller.MondoController">
+
+<SplitPane id="splitPaneMondo" dividerPositions="0.5" focusTraversable="true" xmlns="http://javafx.com/javafx/8.0.111" xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.monarchinitiative.hpoworkbench.controller.MondoController">
 
     <VBox BorderPane.alignment="CENTER">
         <Label styleClass="bluelabel" stylesheets="@../css/style.css" text="Browse MONDO Terms or Diseases">
@@ -38,7 +51,7 @@
                     <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
                 </HBox.margin>
             </TextField>
-            <Button fx:id="goButton" minHeight="30.0" minWidth="-Infinity" mnemonicParsing="false" styleClass="Button" stylesheets="@../css/style.css" text="Go" textOverrun="CLIP">
+            <Button fx:id="goButton" minHeight="30.0" minWidth="-Infinity" mnemonicParsing="false" onAction="#goButtonAction" styleClass="Button" stylesheets="@../css/style.css" text="Go" textOverrun="CLIP">
                 <tooltip>
                     <Tooltip text="tell me what to do" />
                 </tooltip>

--- a/hpowbgui/src/main/resources/resource_bundle/ResourceBundle.properties
+++ b/hpowbgui/src/main/resources/resource_bundle/ResourceBundle.properties
@@ -1,3 +1,4 @@
 status.all.set=All resources set!
 status.download.annotations=Please download HPO annotations file (Edit | Download HPO annotations) 
 status.download.hpo=Please download HPO obo file (Edit | Download HPO) or set path to local one (Edit | Import local copy...)
+status.download.mondo=Please download MONDO obo file (Edit | Download Mondo)

--- a/hpowbgui/src/main/resources/resource_bundle/ResourceBundle_en_US.properties
+++ b/hpowbgui/src/main/resources/resource_bundle/ResourceBundle_en_US.properties
@@ -1,3 +1,4 @@
 status.all.set=All resources set!
 status.download.annotations=Please download HPO annotations file (Edit | Download HPO annotations) 
 status.download.hpo=Please download HPO obo file (Edit | Download HPO) or set path to local one (Edit | Import local copy...)
+status.download.mondo=Please download MONDO obo file (Edit | Download Mondo)


### PR DESCRIPTION
Hi Peter,

I found the bug with Properties. The contract of `setProperty` doesn't allow to use `null` neither as key nor as value. We need to use method `remove` in order to remove the property.

I've also done some progress in the Mondo tab. The Mondo ontology file is being downloaded, but there is some Exception being thrown in the process of parsing of the obo file. 
```
[Thread-4] TRACE (Downloader.java:85) - LocalFilePath: /home/ielis/.hpoworkbench/mondo.obo
[Thread-4] TRACE (Downloader.java:91) - Size of file to be downloaded: 21393894
[Thread-4] INFO  (Downloader.java:103) - Successful download from https://osf.io/e87hn/download: 21393894(21393894) bytes read.
[JavaFX Application Thread] TRACE (MainController.java:184) - Successfully downloaded mondo to /home/ielis/.hpoworkbench
ERROR - 2018-03-26 23:40:07 - /home/ielis/ielis/HPOworkbench/src/main/resources/curie_map.yaml (No such file or directory)
java.io.FileNotFoundException: /home/ielis/ielis/HPOworkbench/src/main/resources/curie_map.yaml (No such file or directory)
	at java.io.FileInputStream.open0(Native Method)
	at java.io.FileInputStream.open(FileInputStream.java:195)
	at java.io.FileInputStream.<init>(FileInputStream.java:138)
	at java.io.FileInputStream.<init>(FileInputStream.java:93)
	at org.monarchinitiative.phenol.io.utils.CurieMapGenerator.generate(CurieMapGenerator.java:27)
	at org.monarchinitiative.phenol.io.owl.OwlImmutableOntologyLoader.<init>(OwlImmutableOntologyLoader.java:60)
	at org.monarchinitiative.hpoworkbench.io.MondoParser.parse(MondoParser.java:38)
	at org.monarchinitiative.hpoworkbench.io.MondoParser.<init>(MondoParser.java:27)
	at org.monarchinitiative.hpoworkbench.controller.MainController.lambda$downloadMondo$2(MainController.java:187)
	at com.sun.javafx.event.CompositeEventHandler.dispatchBubblingEvent(CompositeEventHandler.java:86)
	at com.sun.javafx.event.EventHandlerManager.dispatchBubblingEvent(EventHandlerManager.java:238)
	at com.sun.javafx.event.EventHandlerManager.dispatchBubblingEvent(EventHandlerManager.java:191)
	at com.sun.javafx.event.BasicEventDispatcher.dispatchEvent(BasicEventDispatcher.java:58)
	at com.sun.javafx.event.EventDispatchChainImpl.dispatchEvent(EventDispatchChainImpl.java:114)
	at com.sun.javafx.event.EventUtil.fireEventImpl(EventUtil.java:74)
	at com.sun.javafx.event.EventUtil.fireEvent(EventUtil.java:54)
	at javafx.event.Event.fireEvent(Event.java:198)
	at javafx.concurrent.EventHelper.fireEvent(EventHelper.java:219)
	at javafx.concurrent.Task.fireEvent(Task.java:1356)
	at javafx.concurrent.Task.setState(Task.java:723)
	at javafx.concurrent.Task$TaskCallable.lambda$call$501(Task.java:1434)
	at com.sun.javafx.application.PlatformImpl.lambda$null$172(PlatformImpl.java:295)
	at java.security.AccessController.doPrivileged(Native Method)
	at com.sun.javafx.application.PlatformImpl.lambda$runLater$173(PlatformImpl.java:294)
	at com.sun.glass.ui.InvokeLaterDispatcher$Future.run(InvokeLaterDispatcher.java:95)
	at com.sun.glass.ui.gtk.GtkApplication._runLoop(Native Method)
	at com.sun.glass.ui.gtk.GtkApplication.lambda$null$48(GtkApplication.java:139)
	at java.lang.Thread.run(Thread.java:748)
Exception in thread "JavaFX Application Thread" java.lang.NullPointerException
	at org.prefixcommons.CurieUtil.<init>(CurieUtil.java:24)
	at org.monarchinitiative.phenol.io.owl.OwlImmutableOntologyLoader.<init>(OwlImmutableOntologyLoader.java:60)
	at org.monarchinitiative.hpoworkbench.io.MondoParser.parse(MondoParser.java:38)
	at org.monarchinitiative.hpoworkbench.io.MondoParser.<init>(MondoParser.java:27)
	at org.monarchinitiative.hpoworkbench.controller.MainController.lambda$downloadMondo$2(MainController.java:187)
	at com.sun.javafx.event.CompositeEventHandler.dispatchBubblingEvent(CompositeEventHandler.java:86)
	at com.sun.javafx.event.EventHandlerManager.dispatchBubblingEvent(EventHandlerManager.java:238)
	at com.sun.javafx.event.EventHandlerManager.dispatchBubblingEvent(EventHandlerManager.java:191)
	at com.sun.javafx.event.BasicEventDispatcher.dispatchEvent(BasicEventDispatcher.java:58)
	at com.sun.javafx.event.EventDispatchChainImpl.dispatchEvent(EventDispatchChainImpl.java:114)
	at com.sun.javafx.event.EventUtil.fireEventImpl(EventUtil.java:74)
	at com.sun.javafx.event.EventUtil.fireEvent(EventUtil.java:54)
	at javafx.event.Event.fireEvent(Event.java:198)
	at javafx.concurrent.EventHelper.fireEvent(EventHelper.java:219)
	at javafx.concurrent.Task.fireEvent(Task.java:1356)
	at javafx.concurrent.Task.setState(Task.java:723)
	at javafx.concurrent.Task$TaskCallable.lambda$call$501(Task.java:1434)
	at com.sun.javafx.application.PlatformImpl.lambda$null$172(PlatformImpl.java:295)
	at java.security.AccessController.doPrivileged(Native Method)
	at com.sun.javafx.application.PlatformImpl.lambda$runLater$173(PlatformImpl.java:294)
	at com.sun.glass.ui.InvokeLaterDispatcher$Future.run(InvokeLaterDispatcher.java:95)
	at com.sun.glass.ui.gtk.GtkApplication._runLoop(Native Method)
	at com.sun.glass.ui.gtk.GtkApplication.lambda$null$48(GtkApplication.java:139)
	at java.lang.Thread.run(Thread.java:748)
```
It doesn't look like that the cause for the Exception is missing `mondo.obo` but some part of parsing code which I am not familiar with. I think, that after resolving this issue, we should be able to get the Mondo ontology support working very soon.

Cheers,
Daniel
